### PR TITLE
fix: prevent SSRF via user-supplied URLs

### DIFF
--- a/src/lib/article-fetcher.ts
+++ b/src/lib/article-fetcher.ts
@@ -2,10 +2,52 @@ import * as cheerio from "cheerio";
 import type { Article } from "@/types";
 
 /**
+ * SSRF対策: ユーザー指定URLがプライベートネットワークを指していないか検証する。
+ * - http / https 以外のプロトコルを拒否
+ * - ループバック・RFC1918・リンクローカル（AWS メタデータ含む）を拒否
+ */
+export function validatePublicUrl(urlStr: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlStr);
+  } catch {
+    throw new Error("無効なURLです");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("http/https 以外のプロトコルは許可されていません");
+  }
+
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, ""); // IPv6ブラケット除去
+
+  const BLOCKED_HOSTS = ["localhost", "metadata.google.internal", "::1"];
+  if (BLOCKED_HOSTS.includes(host)) {
+    throw new Error("このURLへのアクセスは許可されていません");
+  }
+
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
+    if (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 169 && b === 254)
+    ) {
+      throw new Error("プライベートIPアドレスへのアクセスは許可されていません");
+    }
+  }
+}
+
+/**
  * URLから記事本文を取得する
  * スクレイピングではなく、公開HTMLの本文テキスト抽出
  */
 export async function fetchArticleFromUrl(url: string): Promise<Article> {
+  validatePublicUrl(url);
+
   const response = await fetch(url, {
     headers: {
       "User-Agent":

--- a/src/lib/rss-parser.ts
+++ b/src/lib/rss-parser.ts
@@ -3,6 +3,7 @@ import type { RssFeedItem } from "@/types";
 import { ALL_FEED_SOURCES, DEFAULT_ENABLED_IDS, type FeedConfig } from "./feed-configs";
 import { fetchNewsdataArticles } from "./newsdata-client";
 import { classifyTopic } from "./topic-classifier";
+import { validatePublicUrl } from "./article-fetcher";
 
 const parser = new Parser({
   timeout: 10000,
@@ -76,6 +77,7 @@ export async function fetchRssFeed(
   sourceName: string,
   filterPolitical = true
 ): Promise<RssFeedItem[]> {
+  validatePublicUrl(feedUrl);
   const feed = await parser.parseURL(feedUrl);
 
   const items = (feed.items ?? []).map((item) => {


### PR DESCRIPTION
Add validatePublicUrl() to article-fetcher.ts that rejects:
- Non-http/https protocols
- Loopback, RFC1918, link-local (169.254.x.x) IP ranges
- Known internal hostnames (localhost, metadata.google.internal)

Apply validation in fetchArticleFromUrl and fetchRssFeed (user-supplied custom feed URLs). Internal feed-configs URLs are not affected.