### PR TITLE
feat(inspect): グルーピング点検 P0/P1/P2 実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 # Prisma generated client
 src/generated/
 .idea/
+
+# go
+.gocache/

--- a/backend/internal/pipeline/collect.go
+++ b/backend/internal/pipeline/collect.go
@@ -35,6 +35,7 @@ func Collect(ctx context.Context, pool *db.Pool, feeds []config.FeedConfig) ([]d
 		close(results)
 	}()
 
+	allowedSources := buildAllowedSources(feeds)
 	seen := make(map[string]bool)
 	var all []db.Article
 
@@ -48,6 +49,10 @@ func Collect(ctx context.Context, pool *db.Pool, feeds []config.FeedConfig) ([]d
 			if a.URL == "" || seen[a.URL] {
 				continue
 			}
+			if _, ok := allowedSources[a.Source]; !ok {
+				slog.Debug("skip article from non-target source", "feed", r.name, "source", a.Source, "url", a.URL)
+				continue
+			}
 			seen[a.URL] = true
 			all = append(all, a)
 		}
@@ -58,4 +63,25 @@ func Collect(ctx context.Context, pool *db.Pool, feeds []config.FeedConfig) ([]d
 	}
 	slog.Info("collect done", "articles", len(all))
 	return all, nil
+}
+
+func buildAllowedSources(feeds []config.FeedConfig) map[string]struct{} {
+	allowed := make(map[string]struct{}, len(feeds))
+	for _, f := range feeds {
+		// Generic Google News topic feeds are collection helpers, not media brands.
+		// Only feeds with a canonical source count as a target media source.
+		if f.Type == "google-news" && f.CanonicalSource == "" {
+			continue
+		}
+
+		source := f.Name
+		if f.CanonicalSource != "" {
+			source = f.CanonicalSource
+		}
+		if source == "" {
+			continue
+		}
+		allowed[source] = struct{}{}
+	}
+	return allowed
 }

--- a/docs/grouping-inspection-design.md
+++ b/docs/grouping-inspection-design.md
@@ -2,328 +2,401 @@
 
 ## 背景
 
-バッチで生成されたニュースグループが、なぜその構成になったのかを調査し、必要に応じて修正する仕組みが必要。点検はスナップショット単位で、特定グループの記事構成を詳細に診断する流れを設計。
+バッチで生成されたニュースグループについて、
+
+- なぜその構成になったのかを確認したい
+- 表示上の補正をしたい
+- 将来の改善に使えるフィードバックを残したい
+
+という要求がある。
+
+この3つは似ているが、実装上は別物である。ここでは以下の4層に分けて整理する。
+
+1. **閲覧専用の点検**
+2. **再計算を伴う診断**
+3. **表示上の手動補正**
+4. **将来改善のためのフィードバック記録**
 
 ---
 
-## 問題構造（3層）
+## 問題構造
 
 | 層 | 原因 | 例 | 対応 |
 |:--|:--|:--|:--|
-| **Embedding** | ベクトル化が不正確 | 「石破首相が訪米」と「石破首相が記者会見」の意味的距離が近すぎる | モデル/プリセット改善（長期） |
-| **Clustering** | 閾値or greedy順序の問題 | 本来別トピックだがコサイン類似度が閾値を超えて合流 | 閾値調整・シミュレーション |
-| **Naming** | グループ自体は正しいが名前が悪い | 実態と合わないタイトルが付く | 採用グループタイトルの修正 |
+| **Embedding** | ベクトル化が不正確 | 「石破首相が訪米」と「石破首相が記者会見」の意味的距離が近すぎる | モデル/プリセット改善 |
+| **Clustering** | 閾値や greedy 順序の問題 | 本来別トピックだが類似度閾値を超えて合流 | 再計算診断・閾値調整 |
+| **Naming** | グループ自体は妥当だがタイトルが悪い | 実態と合わない名前が付く | 表示タイトル補正 |
+| **運用補正** | 一部記事だけ表示上の扱いを変えたい | 1件だけ除外したい | overlay で補正 |
 
-UI上の直感「このグループにこの記事が入っているのはおかしい」から、データ診断を通じて原因層を特定し対応を判断する。
+UI上の「このグループにこの記事がいるのはおかしい」は、必ずしも同じ原因ではない。  
+まずは「保存済みデータだけで見える異常」なのか、「再計算しないと分からない原因」なのかを分ける。
 
 ---
 
-## 診断API: `GET /api/batch/inspect?snapshotId=<id>&groupId=<id>`
+## 1. 閲覧専用の点検
 
-### リクエスト
-```bash
-GET /api/batch/inspect?snapshotId=abc123&groupId=xyz789
-```
+### 目的
 
-### レスポンス
+まずは現在のスナップショットを壊さずに、保存済みデータだけで確認できる情報を出す。
+
+### 対象ルート
+
+- 既存 `/inspect` の snapshot タブ拡張を第一候補とする
+- その後、必要なら `/inspect/[snapshotId]/[groupId]` の詳細画面へ分離する
+
+### 保存済みデータだけで表示できる項目
+
+- スナップショットメタ情報
+- グループタイトル
+- グループのカテゴリ / サブカテゴリ
+- 記事一覧
+- 媒体数
+- `coveredBy` / `silentMedia`
+- カテゴリ混在の有無
+- 単独報道かどうか
+
+### 閲覧専用API
+
+`GET /api/batch/inspect?snapshotId=<id>&groupId=<id>`
+
+このAPIは **DBに保存済みの情報だけ** を返す。
+
 ```json
 {
   "snapshotId": "abc123",
   "groupId": "xyz789",
   "groupTitle": "石破首相の外交動向",
-  "dominantCategory": "politics",
-  "threshold": 0.87,
+  "category": "politics",
+  "subcategory": "diplomacy",
+  "rank": 3,
+  "singleOutlet": false,
+  "coveredBy": ["NHK", "朝日新聞"],
+  "silentMedia": ["読売新聞", "日本経済新聞"],
   "articles": [
     {
-      "url": "https://nhk.jp/...",
       "title": "石破首相が訪米、バイデン大統領と会談",
+      "url": "https://nhk.jp/...",
       "source": "NHK",
+      "publishedAt": "2026-04-08T10:30:00Z",
       "category": "politics",
-      "published_at": "2026-04-08T10:30:00Z",
-      "similarity_to_centroid": 0.951,
-      "cross_category_penalty_applied": false,
-      "similarity_before_penalty": 0.951,
-      "similarity_after_penalty": 0.951,
-      "nearest_neighbors": [
-        {
-          "url": "https://asahi.jp/...",
-          "title": "首相訪米の狙いは半導体供給網強化",
-          "similarity": 0.923
-        },
-        {
-          "url": "https://yomiuri.jp/...",
-          "title": "日米首脳会談、経済安保でも協調",
-          "similarity": 0.918
-        }
-      ]
+      "subcategory": "diplomacy",
+      "summary": "..."
     },
+    {
+      "title": "石破首相、記者会見で経済対策に言及",
+      "url": "https://asahi.jp/...",
+      "source": "朝日新聞",
+      "publishedAt": "2026-04-08T11:45:00Z",
+      "category": "economy",
+      "subcategory": "fiscal_policy",
+      "summary": "..."
+    }
+  ],
+  "summary": {
+    "totalArticles": 2,
+    "byCategory": {
+      "politics": 1,
+      "economy": 1
+    },
+    "issues": [
+      {
+        "type": "cross_category_mismatch",
+        "severity": "medium",
+        "message": "カテゴリが混在している"
+      }
+    ]
+  }
+}
+```
+
+### この段階でやらないこと
+
+- 類似度の説明
+- centroid との距離
+- nearest neighbors
+- alternative clusters
+- 閾値変更シミュレーション
+
+これらは保存済みデータだけでは安定して出せないため、次の「再計算診断」に分離する。
+
+---
+
+## 2. 再計算を伴う診断
+
+### 目的
+
+「なぜ入ったのか」「どこに入るべきだったか」を、埋め込みとクラスタリングロジックを使って再診断する。
+
+### 前提
+
+この診断は **DB参照だけでは完結しない**。
+
+- 記事 embedding が必要
+- 当時のクラスタリング条件が必要
+- greedy clustering のため、記事順序も再現対象になる
+- カテゴリ不一致ペナルティの有無を再計算する必要がある
+
+### 診断API
+
+`POST /api/batch/inspect/recompute`
+
+```json
+{
+  "snapshotId": "abc123",
+  "groupId": "xyz789"
+}
+```
+
+### 返してよい項目
+
+- `thresholdUsed`
+- `similarityToCentroid`
+- `similarityBeforePenalty`
+- `similarityAfterPenalty`
+- `crossCategoryPenaltyApplied`
+- `nearestNeighbors`
+- `alternativeClusters`
+
+### レスポンス例
+
+```json
+{
+  "snapshotId": "abc123",
+  "groupId": "xyz789",
+  "thresholdUsed": 0.87,
+  "articles": [
     {
       "url": "https://asahi.jp/...",
       "title": "石破首相、記者会見で経済対策に言及",
-      "source": "朝日新聞",
-      "category": "economy",
-      "published_at": "2026-04-08T11:45:00Z",
-      "similarity_to_centroid": 0.874,
-      "cross_category_penalty_applied": true,
-      "similarity_before_penalty": 0.874,
-      "similarity_after_penalty": 0.612,
-      "penalty_reason": "カテゴリ不一致（economy ≠ politics）",
-      "nearest_neighbors": [
+      "similarityToCentroid": 0.874,
+      "similarityBeforePenalty": 0.874,
+      "similarityAfterPenalty": 0.612,
+      "crossCategoryPenaltyApplied": true,
+      "nearestNeighbors": [
         {
           "url": "https://nikkei.jp/...",
           "title": "政府の経済対策、6月に策定へ",
           "similarity": 0.856
         }
       ],
-      "alternative_clusters": [
+      "alternativeClusters": [
         {
           "groupId": "alt001",
           "groupTitle": "政府の経済対策",
-          "similarity_to_that_centroid": 0.821,
-          "reason": "economic カテゴリ一致、経済対策テーマ"
-        },
-        {
-          "groupId": "alt002",
-          "groupTitle": "首相の政策声明",
-          "similarity_to_that_centroid": 0.798
+          "similarityToCentroid": 0.821
         }
       ]
     }
-  ],
-  "summary": {
-    "total_articles": 2,
-    "by_category": { "politics": 1, "economy": 1 },
-    "similarity_range": { "min": 0.612, "max": 0.951, "mean": 0.8825 },
-    "issues": [
-      {
-        "type": "cross_category_mismatch",
-        "article_url": "https://asahi.jp/...",
-        "severity": "medium",
-        "message": "economy カテゴリの記事が政治グループに混入（ペナルティ適用後 0.612 で境界ぎりぎり）"
-      }
-    ]
-  }
+  ]
 }
 ```
 
-### ポイント
-- **similarity_to_centroid**: グループ重心との類似度 → 低いほど「ギリギリ混入」
-- **cross_category_penalty_applied**: カテゴリ不一致による0.7ペナルティが適用されたか
-- **nearest_neighbors**: グループ内で最も近い記事 → 「何に引きずられて入ったか」の理由
-- **alternative_clusters**: 他グループとの類似度 → 「本来ここに入るべきだった」候補
-- **summary.issues**: 自動検出された問題（カテゴリミスマッチ、外れ値など）
+### 注意
+
+このAPIは「保存済み事実の表示」ではなく、**現行ロジックでの再解釈** である。  
+そのため、レスポンスには以下を含める。
+
+- 使用した threshold
+- カテゴリペナルティ係数
+- 再計算対象の記事数
+- 再計算時刻
+
+必要なら将来的に、スナップショット作成時の `threshold` を別カラムで保持する。
 
 ---
 
-## 修正アクション API
+## 3. 表示上の手動補正
 
-### 1. 記事をグループから除外
-```bash
-POST /api/batch/inspect/exclude
-Content-Type: application/json
+### 目的
 
-{
-  "snapshotId": "abc123",
-  "articleUrl": "https://asahi.jp/...",
-  "groupId": "xyz789",
-  "reason": "カテゴリが異なり経済対策グループに入るべき"
-}
-```
+ランキングや公開表示での見え方を補正したいが、元のバッチ結果は壊したくない。
 
-**効果**: スナップショット内のグループから記事を削除。他グループへの移動はしない（orphan状態）
+### 方針
 
-### 2. 記事を別グループに移動
-```bash
-POST /api/batch/inspect/move
-Content-Type: application/json
+`processed_snapshots` / `snapshot_groups` / `snapshot_group_items` は **元データとして不変** に保つ。  
+手動修正はスナップショット本体を書き換えず、overlay テーブルとして別管理する。
 
-{
-  "snapshotId": "abc123",
-  "articleUrl": "https://asahi.jp/...",
-  "fromGroupId": "xyz789",
-  "toGroupId": "alt001",
-  "reason": "経済カテゴリマッチのため移動"
-}
-```
+### やってはいけないこと
 
-**効果**: スナップショット内で記事をグループ間で移動
+- `snapshot_group_items` から直接 DELETE
+- 記事を別グループへ直接 UPDATE
+- スナップショット本体を運用操作で書き換える
 
-### 3. 閾値シミュレーション（dry run）
-```bash
-POST /api/batch/inspect/simulate-threshold
-Content-Type: application/json
+これをやると、
 
-{
-  "snapshotId": "abc123",
-  "threshold": 0.90
-}
-```
+- バッチ結果の再現性が失われる
+- 後から原因分析できなくなる
+- 次回バッチとの差分比較が壊れる
 
-**レスポンス例**:
+### 補正アクションの種類
+
+- 記事を非表示にする
+- 記事を別グループに表示上だけ移す
+- グループタイトルを上書きする
+- グループ自体を公開面から除外する
+
+### API案
+
+`POST /api/batch/inspect/overrides`
+
 ```json
 {
-  "original": {
-    "threshold": 0.87,
-    "group_count": 15,
-    "groups": [
-      {
-        "groupId": "xyz789",
-        "groupTitle": "石破首相の外交動向",
-        "article_count": 2
-      }
-    ]
-  },
-  "simulated": {
-    "threshold": 0.90,
-    "group_count": 16,
-    "groups": [
-      {
-        "groupId": "xyz789",
-        "groupTitle": "石破首相の外交動向",
-        "article_count": 1,
-        "removed_articles": ["https://asahi.jp/..."]
-      },
-      {
-        "groupId": "new_001",
-        "groupTitle": "石破首相の経済発言",
-        "article_count": 1,
-        "articles": ["https://asahi.jp/..."]
-      }
-    ]
-  },
-  "impact": {
-    "new_groups": 1,
-    "merged_groups": 0,
-    "regrouped_articles": 1
-  }
+  "snapshotId": "abc123",
+  "groupId": "xyz789",
+  "action": "hide_article",
+  "articleUrl": "https://asahi.jp/...",
+  "reason": "カテゴリが異なり表示上は除外したい"
 }
 ```
 
-**効果**: 閾値を変えたらグルーピングがどう変わるかを表示（実際には反映しない）
+または
 
-### 4. フィードバック記録
-```bash
-POST /api/batch/inspect/feedback
-Content-Type: application/json
-
+```json
 {
   "snapshotId": "abc123",
-  "articleUrl": "https://asahi.jp/...",
   "groupId": "xyz789",
-  "action": "should_not_be_here",
-  "confidence": 0.9,
-  "reason": "カテゴリ economy なのに politics グループ"
+  "action": "rename_group",
+  "title": "石破首相の訪米と日米首脳会談",
+  "reason": "元タイトルが広すぎる"
 }
 ```
 
-**効果**: 将来の閾値チューニングや モデルの学習用フィードバック記録
+### 読み出しルール
+
+- 内部点検画面では「元データ」と「override適用後」の両方を見られるようにする
+- 公開面では override 適用後のみを表示する
 
 ---
 
-## 点検UI: `/inspect/[snapshotId]/[groupId]`
+## 4. フィードバック記録
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│ 点検: 石破首相の外交動向         [スナップショット選択] [×] │
-├─────────────────────────────────────────────────────────────┤
-│ 閾値: 0.87  カテゴリ: politics   記事数: 2 / 合計メディア: 2 │
-├─────────────────────────────────────────────────────────────┤
-│                                                               │
-│ 記事一覧（類似度 降順）                                        │
-│ ┌───────────────────────────────────────────────────────┐    │
-│ │ ●●● 0.951                                   [詳細]   │    │
-│ │ ⬤ NHK  石破首相が訪米、バイデン大統領と会談        │    │
-│ │ 2026-04-08 10:30 | politics                          │    │
-│ │ センテンス内類似: ⚫⚫⚫⚫⚪ (4/5)                    │    │
-│ │ 判定: ✅ 正常  [除外] [移動]                          │    │
-│ ├───────────────────────────────────────────────────────┤    │
-│ │ ●●● 0.874  ⚠️ カテゴリ警告                    [詳細] │    │
-│ │ ⬤ 朝日 石破首相、会見で経済対策に言及               │    │
-│ │ 2026-04-08 11:45 | economy ← politics と不一致       │    │
-│ │ ペナルティ適用: 0.874 × 0.7 = 0.612 (ギリギリ)      │    │
-│ │ 近い記事: 「政府の経済対策」グループ (0.821)        │    │
-│ │ 判定: ⚠️  要検討  [除外] [移動→経済対策]             │    │
-│ └───────────────────────────────────────────────────────┘    │
-│                                                               │
-│ 統計                                                          │
-│ 類似度分布: ████████░░ (0.612 ～ 0.951 | μ=0.883)           │
-│ カテゴリ分布: politics(50%) economy(50%) ⚠ 混在              │
-│ 問題検出: ⚠️ 1件 (カテゴリ不一致)                            │
-│                                                               │
-│ [アクション]                                                  │
-│ ┌──────────────────────────────────┐                         │
-│ │ 閾値シミュレーション              │                         │
-│ │ 現在: 0.87                        │                         │
-│ │ ┌──●────────────┐                │                         │
-│ │ 0.80          0.95              │                         │
-│ │ → 0.90に変更: グループ15→16 (+1分割) │                    │
-│ │                                  │                         │
-│ │ [フィードバック送信] [スナップショット適用] │               │
-│ └──────────────────────────────────┘                         │
-└─────────────────────────────────────────────────────────────┘
+### 目的
+
+今すぐ表示を変えるのではなく、将来の改善材料を残す。
+
+### 特徴
+
+- 表示結果を変えない
+- スナップショットも変えない
+- 運用者の判断ログだけを蓄積する
+
+### API案
+
+`POST /api/batch/inspect/feedback`
+
+```json
+{
+  "snapshotId": "abc123",
+  "groupId": "xyz789",
+  "articleUrl": "https://asahi.jp/...",
+  "action": "should_not_be_here",
+  "confidence": 0.9,
+  "reason": "economy 記事なのに politics グループに見える"
+}
 ```
 
-### 表示要素
-1. **記事カード**: 類似度, 警告フラグ, アクション
-2. **統計**: 類似度ヒストグラム, カテゴリ分布, 自動検出された問題
-3. **シミュレーション**: 閾値スライダーで再グルーピング結果を即座に表示
-4. **アクション**: 除外/移動/フィードバック送信
+### 用途
+
+- threshold 調整の参考
+- カテゴリペナルティ係数の見直し
+- embedding モデルの変更判断
+- 命名ロジック改善の入力
+
+---
+
+## UI整理
+
+### 画面の役割
+
+- `/inspect`
+  - 一覧確認
+  - 問題がありそうなグループを見つける
+- `/inspect/[snapshotId]/[groupId]`
+  - 1グループの詳細点検
+  - 元データ表示
+  - 再計算診断
+  - override 操作
+  - feedback 登録
+
+### 詳細画面の表示ブロック
+
+1. **保存済みデータ**
+2. **自動検出された軽微な異常**
+3. **再計算診断結果**
+4. **override 操作**
+5. **feedback 登録**
 
 ---
 
 ## 実装フェーズ
 
-| Phase | 内容 | 工数 | 依存関係 |
+| Phase | 内容 | 工数 | 備考 |
 |:--|:--|:--|:--|
-| **P0** | スナップショットに `similarity` を保存（スキーマ変更） | 小 | なし |
-| **P1** | 診断API（Goバッチ側） | 小 | P0 |
-| **P2** | 点検UI（フロント） | 中 | P1 |
-| **P3** | 除外/移動アクション（スナップショット書き換え） | 小 | P2 |
-| **P4** | 閾値シミュレーション（dry run再グルーピング） | 中 | P1 |
-| **P5** | フィードバック記録・自動チューニング（長期） | 大 | P4 |
+| **P0** ✅ | `/inspect` の snapshot 詳細表示拡張 | 小 | 保存済みデータのみ |
+| **P1** ✅ | `GET /api/batch/inspect` | 小 | DB参照のみ |
+| **P2** ✅ | 軽微な自動警告 | 小 | カテゴリ混在など |
+| **P3** | `POST /api/batch/inspect/recompute` | 中 | embedding と再計算が必要 |
+| **P4** | override テーブル追加 | 中 | 元スナップショットは不変 |
+| **P5** | override 操作UI | 中 | 表示補正 |
+| **P6** | feedback 記録 | 小 | 表示には未反映 |
+| **P7** | 閾値シミュレーション | 中 | 再計算系の延長 |
 
-### P0: スキーマ変更
-`SnapshotGroupItem` に以下カラムを追加:
+---
+
+## スキーマ変更の扱い
+
+### すぐ必要なもの
+
+閲覧専用の点検だけなら、まず追加カラムなしでも着手できる。
+
+### 将来的にあるとよいもの
+
+再計算説明を安定化するため、将来的には以下を保存候補にする。
+
+- スナップショット作成時の threshold
+- カテゴリペナルティ係数
+- 記事投入順
+
+### SQL例
+
+物理テーブル名は `snake_case` を使う。
+
 ```sql
-ALTER TABLE "SnapshotGroupItem" ADD COLUMN "similarity" FLOAT;
-ALTER TABLE "SnapshotGroupItem" ADD COLUMN "category_mismatch" BOOLEAN;
-ALTER TABLE "SnapshotGroupItem" ADD COLUMN "similarity_before_penalty" FLOAT;
+ALTER TABLE snapshot_group_items ADD COLUMN similarity FLOAT;
+ALTER TABLE snapshot_group_items ADD COLUMN category_mismatch BOOLEAN;
+ALTER TABLE snapshot_group_items ADD COLUMN similarity_before_penalty FLOAT;
 ```
 
-バッチ側: `store.go` で `SnapshotGroupItem` を保存する際に、各記事の類似度をDBに記録
+ただし、これらは **必須ではない**。  
+P0-P2 は既存スキーマのままでも進められる。
 
 ---
 
 ## 運用フロー
 
-1. **ランキングページで「あれ？」と気づく**
-   → 該当グループをクリック → `/inspect/[snapshotId]/[groupId]`
-
-2. **診断ページで詳細確認**
-   → 類似度, カテゴリ警告, 代替グループ候補を閲覧
-   → 問題が明らか → アクション選択
-
-3. **修正実行**
-   - 除外: 記事削除
-   - 移動: 別グループへ
-   - 閾値調整: シミュレーション確認後、フィードバック記録 → 次回バッチ時に適用
-
-4. **フィードバック蓄積**
-   → 閾値の自動チューニング、またはモデル改善の根拠へ
+1. ランキングや `/inspect` 一覧で違和感を見つける
+2. `GET /api/batch/inspect` で保存済みデータを確認する
+3. 必要なら `recompute` を実行して、原因が embedding / clustering / naming のどこに近いかを見る
+4. 表示上の補正が必要なら override を作る
+5. 将来改善に回したい判断は feedback として残す
 
 ---
 
-## 技術的留意点
+## 判断基準
 
-### グループ重心（Centroid）の保存 vs リアルタイム計算
-- **事前保存**: 点検はスナップショット完結。ただしスキーマ拡張必要
-- **リアルタイム計算**: 記事embeddingが必要（3日で期限切れ）
+### override を使うケース
 
-→ **推奨: 事前保存**。スナップショットの自己完結性と安定性を優先
+- 今すぐ公開表示を直したい
+- ただし元のバッチ結果は保持したい
 
-### 閾値シミュレーション
-診断API呼び出し時にリアルタイムで `GroupArticles` を再実行し、異なる閾値でのグルーピング結果をシミュレート。実際には反映しない（dry run）。
+### feedback だけでよいケース
 
-### フィードバックとしての記録
-`exclude / move` アクションと別に、単純に「この記事はこのグループにいるべきではない」というマーク。将来的に機械学習や統計的に閾値を最適化する時の学習データに。
+- まだ表示を変えるほどではない
+- 傾向を観察したい
+- 将来の閾値調整に回したい
 
+### 再計算診断が必要なケース
+
+- 「なぜこのグループに入ったのか」の説明が欲しい
+- 代替候補グループを見たい
+- threshold 変更の影響を見たい

--- a/src/app/api/batch/inspect/route.ts
+++ b/src/app/api/batch/inspect/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSnapshotGroupDetail } from "@/lib/db";
+
+export async function GET(req: NextRequest) {
+  const snapshotId = req.nextUrl.searchParams.get("snapshotId");
+  const groupId    = req.nextUrl.searchParams.get("groupId");
+
+  if (!snapshotId || !groupId) {
+    return NextResponse.json({ error: "snapshotId と groupId は必須" }, { status: 400 });
+  }
+
+  try {
+    const detail = await getSnapshotGroupDetail(snapshotId, groupId);
+    if (!detail) {
+      return NextResponse.json({ error: "グループが見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(detail);
+  } catch (e) {
+    console.error("[inspect]", e);
+    return NextResponse.json({ error: "取得失敗" }, { status: 500 });
+  }
+}

--- a/src/app/inspect/page.tsx
+++ b/src/app/inspect/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import type { NewsGroup } from "@/types";
-import type { SnapshotMeta, FeedGroupWithItems } from "@/lib/db";
+import type { SnapshotMeta, FeedGroupWithItems, GroupInspectDetail } from "@/lib/db";
 
 type Tab = "feed" | "snapshot";
 
@@ -34,6 +34,21 @@ function SourceBadge({ count }: { count: number }) {
   );
 }
 
+const SEVERITY_CLS: Record<string, string> = {
+  high:   "bg-red-50 text-red-700 border-red-200",
+  medium: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  low:    "bg-gray-50 text-gray-500 border-gray-200",
+};
+
+function IssueBadge({ count }: { count: number }) {
+  if (count === 0) return null;
+  return (
+    <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-700 shrink-0">
+      警告{count}
+    </span>
+  );
+}
+
 export default function InspectPage() {
   const [tab, setTab] = useState<Tab>("feed");
 
@@ -48,6 +63,9 @@ export default function InspectPage() {
 
   const [expandedFeed, setExpandedFeed] = useState<Set<string>>(new Set());
   const [expandedSnap, setExpandedSnap] = useState<Set<string>>(new Set());
+
+  // groupId → inspect detail（lazy fetch）
+  const [inspectCache, setInspectCache] = useState<Map<string, GroupInspectDetail | null>>(new Map());
 
   useEffect(() => {
     setFeedLoading(true);
@@ -81,10 +99,25 @@ export default function InspectPage() {
     });
   }
 
-  function toggleSnap(id: string) {
+  function toggleSnap(groupId: string, snapshotId: string) {
     setExpandedSnap((prev) => {
       const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+        // キャッシュ済みでなければ fetch
+        if (!inspectCache.has(groupId)) {
+          fetch(`/api/batch/inspect?snapshotId=${snapshotId}&groupId=${groupId}`)
+            .then((r) => r.json())
+            .then((d: GroupInspectDetail) => {
+              setInspectCache((c) => new Map(c).set(groupId, d));
+            })
+            .catch(() => {
+              setInspectCache((c) => new Map(c).set(groupId, null));
+            });
+        }
+      }
       return next;
     });
   }
@@ -141,7 +174,6 @@ export default function InspectPage() {
             )}
             {!feedLoading && !feedError && (
               <>
-                {/* サマリー */}
                 <div className="flex gap-4 mb-4 text-xs text-gray-500">
                   <span>グループ総数: <strong className="text-gray-800">{feedGroups.length}</strong></span>
                   <span>多媒体: <strong className="text-green-700">{multiOutletFeed}</strong></span>
@@ -236,14 +268,19 @@ export default function InspectPage() {
                 ) : (
                   <div className="space-y-1">
                     {snapshotGroups.map((g, i) => {
-                      const key = `${g.rank ?? i}-${g.groupTitle}`;
-                      const open = expandedSnap.has(key);
-                      const covered  = g.coveredBy   ?? [];
-                      const silent   = g.silentMedia  ?? [];
+                      const groupId = g.id ?? `${g.rank ?? i}-${g.groupTitle}`;
+                      const open    = expandedSnap.has(groupId);
+                      const detail  = inspectCache.get(groupId) ?? null;
+                      const covered = g.coveredBy  ?? [];
+                      const silent  = g.silentMedia ?? [];
+                      const issueCount = detail?.summary.issues.length ?? 0;
                       return (
-                        <div key={key} className={`rounded-lg border bg-white ${g.singleOutlet ? "opacity-60" : ""}`}>
+                        <div key={groupId} className={`rounded-lg border bg-white ${g.singleOutlet ? "opacity-60" : ""}`}>
                           <button
-                            onClick={() => toggleSnap(key)}
+                            onClick={() => snapshot && g.id
+                              ? toggleSnap(g.id, snapshot.id)
+                              : undefined
+                            }
                             className="w-full flex items-center gap-2 px-3 py-2.5 text-left"
                           >
                             {g.rank != null && (
@@ -267,25 +304,68 @@ export default function InspectPage() {
                                 沈黙{silent.length}
                               </span>
                             )}
+                            <IssueBadge count={issueCount} />
                             <span className="text-gray-400 text-xs shrink-0">{open ? "▼" : "▶"}</span>
                           </button>
+
                           <div className={`ranking-expand ${open ? "open" : ""}`}>
-                            <div>
-                              <div className="border-t border-gray-100 px-3 py-2 space-y-2">
-                                {/* 媒体リスト */}
-                                {(covered.length > 0 || silent.length > 0) && (
-                                  <div className="flex flex-wrap gap-2 text-xs">
-                                    {covered.map((m) => (
-                                      <span key={m} className="bg-green-50 text-green-700 px-2 py-0.5 rounded">{m}</span>
-                                    ))}
-                                    {silent.map((m) => (
-                                      <span key={m} className="bg-gray-50 text-gray-400 px-2 py-0.5 rounded line-through">{m}</span>
-                                    ))}
-                                  </div>
-                                )}
-                                {/* 記事リスト */}
-                                <ul className="divide-y divide-gray-50">
-                                  {g.items.map((item, j) => (
+                            <div className="border-t border-gray-100">
+                              {/* ローディング */}
+                              {open && !detail && inspectCache.has(groupId) === false && (
+                                <div className="flex items-center gap-2 px-3 py-2 text-xs text-gray-400">
+                                  <div className="w-3 h-3 border border-gray-300 border-t-blue-400 rounded-full animate-spin" />
+                                  読み込み中…
+                                </div>
+                              )}
+                              {open && !inspectCache.has(groupId) && (
+                                <div className="flex items-center gap-2 px-3 py-2 text-xs text-gray-400">
+                                  <div className="w-3 h-3 border border-gray-300 border-t-blue-400 rounded-full animate-spin" />
+                                  読み込み中…
+                                </div>
+                              )}
+
+                              {/* Issues */}
+                              {detail && detail.summary.issues.length > 0 && (
+                                <div className="px-3 pt-2 space-y-1">
+                                  {detail.summary.issues.map((issue, k) => (
+                                    <div
+                                      key={k}
+                                      className={`text-xs px-2 py-1 rounded border ${SEVERITY_CLS[issue.severity] ?? SEVERITY_CLS.low}`}
+                                    >
+                                      {issue.message}
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+
+                              {/* カテゴリ内訳（混在時のみ） */}
+                              {detail && Object.keys(detail.summary.byCategory).length >= 2 && (
+                                <div className="px-3 pt-2 flex flex-wrap gap-1">
+                                  {Object.entries(detail.summary.byCategory).map(([cat, cnt]) => (
+                                    <span key={cat} className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
+                                      {cat} {cnt}件
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+
+                              {/* 媒体リスト */}
+                              {(covered.length > 0 || silent.length > 0) && (
+                                <div className="flex flex-wrap gap-2 px-3 pt-2 text-xs">
+                                  {covered.map((m) => (
+                                    <span key={m} className="bg-green-50 text-green-700 px-2 py-0.5 rounded">{m}</span>
+                                  ))}
+                                  {silent.map((m) => (
+                                    <span key={m} className="bg-gray-50 text-gray-400 px-2 py-0.5 rounded line-through">{m}</span>
+                                  ))}
+                                </div>
+                              )}
+
+                              {/* 記事リスト（inspect detail があれば category も表示） */}
+                              <ul className="px-3 pt-2 pb-2 divide-y divide-gray-50">
+                                {(detail?.articles ?? g.items).map((item, j) => {
+                                  const cat = "category" in item ? item.category : null;
+                                  return (
                                     <li key={j} className="flex items-start gap-2 py-1.5">
                                       <span className="text-xs font-semibold text-gray-500 shrink-0 w-24 truncate">{item.source}</span>
                                       <a
@@ -296,13 +376,18 @@ export default function InspectPage() {
                                       >
                                         {item.title}
                                       </a>
+                                      {cat && (
+                                        <span className="text-[10px] bg-blue-50 text-blue-500 px-1.5 py-0.5 rounded shrink-0">
+                                          {cat}
+                                        </span>
+                                      )}
                                       <span className="text-xs text-gray-400 shrink-0 whitespace-nowrap">
                                         {item.publishedAt ? formatRelative(item.publishedAt) : "—"}
                                       </span>
                                     </li>
-                                  ))}
-                                </ul>
-                              </div>
+                                  );
+                                })}
+                              </ul>
                             </div>
                           </div>
                         </div>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -485,6 +485,110 @@ export async function getRssArticlesBetween(since: Date, until: Date, sources?: 
 
 // ── ProcessedSnapshot ─────────────────────────────────────
 
+export interface GroupIssue {
+  type: "cross_category_mismatch" | "no_category" | "subcategory_mismatch";
+  severity: "low" | "medium" | "high";
+  message: string;
+}
+
+export interface GroupInspectDetail {
+  snapshotId:   string;
+  groupId:      string;
+  groupTitle:   string;
+  category:     string | null;
+  subcategory:  string | null;
+  rank:         number;
+  singleOutlet: boolean;
+  coveredBy:    string[];
+  silentMedia:  string[];
+  articles: Array<{
+    title:       string;
+    url:         string;
+    source:      string;
+    publishedAt: string | null;
+    category:    string | null;
+    subcategory: string | null;
+    summary:     string | null;
+  }>;
+  summary: {
+    totalArticles: number;
+    byCategory:    Record<string, number>;
+    issues:        GroupIssue[];
+  };
+}
+
+/** スナップショット内の特定グループを取得し、自動検出 issue を付与して返す */
+export async function getSnapshotGroupDetail(
+  snapshotId: string,
+  groupId: string,
+): Promise<GroupInspectDetail | null> {
+  const group = await getPrisma().snapshotGroup.findFirst({
+    where: { id: groupId, snapshotId },
+    include: { items: { orderBy: [{ source: "asc" }, { publishedAt: "asc" }] } },
+  });
+  if (!group) return null;
+
+  const articles = group.items.map((item) => ({
+    title:       item.title,
+    url:         item.url,
+    source:      item.source,
+    publishedAt: item.publishedAt ?? null,
+    category:    item.category ?? null,
+    subcategory: item.subcategory ?? null,
+    summary:     item.summary ?? null,
+  }));
+
+  // カテゴリ集計
+  const byCategory: Record<string, number> = {};
+  for (const a of articles) {
+    const cat = a.category ?? "(未分類)";
+    byCategory[cat] = (byCategory[cat] ?? 0) + 1;
+  }
+
+  // Issue 検出（P2）
+  const issues: GroupIssue[] = [];
+
+  const cats = Object.keys(byCategory).filter((c) => c !== "(未分類)");
+  if (cats.length >= 2) {
+    issues.push({
+      type:     "cross_category_mismatch",
+      severity: "medium",
+      message:  `カテゴリが${cats.length}種類混在 (${cats.join(", ")})`,
+    });
+  }
+
+  if (!group.category) {
+    issues.push({
+      type:     "no_category",
+      severity: "low",
+      message:  "グループカテゴリが未設定",
+    });
+  }
+
+  const subcats = new Set(articles.map((a) => a.subcategory).filter(Boolean));
+  if (subcats.size >= 3) {
+    issues.push({
+      type:     "subcategory_mismatch",
+      severity: "low",
+      message:  `サブカテゴリが${subcats.size}種類混在`,
+    });
+  }
+
+  return {
+    snapshotId,
+    groupId:      group.id,
+    groupTitle:   group.groupTitle,
+    category:     group.category ?? null,
+    subcategory:  group.subcategory ?? null,
+    rank:         group.rank,
+    singleOutlet: group.singleOutlet,
+    coveredBy:    Array.isArray(group.coveredBy)  ? (group.coveredBy  as string[]) : [],
+    silentMedia:  Array.isArray(group.silentMedia) ? (group.silentMedia as string[]) : [],
+    articles,
+    summary: { totalArticles: articles.length, byCategory, issues },
+  };
+}
+
 export interface SnapshotMeta {
   id:           string;
   processedAt:  string;
@@ -517,6 +621,7 @@ export async function getLatestSnapshot(): Promise<SnapshotResult> {
   if (!snap) return { snapshot: null, groups: [] };
 
   const groups: NewsGroup[] = snap.groups.map((g) => ({
+    id:           g.id,
     groupTitle:   g.groupTitle,
     singleOutlet: g.singleOutlet,
     category:     g.category ?? undefined,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,7 @@ export interface NewsGroup {
   category?: string;         // グループ内の支配的大分類（"politics" | "economy" | ...）
   subcategory?: string;      // グループ内の支配的中分類
   // SnapshotGroup 由来フィールド（/inspect ページで使用）
+  id?:          string;
   rank?:        number;
   coveredBy?:   string[];
   silentMedia?: string[];


### PR DESCRIPTION
## Summary

- `GET /api/batch/inspect` を新設（P1）- snapshotId + groupId でグループ詳細をDB参照のみで返す
- Issue自動検出（P2）- `cross_category_mismatch` / `no_category` / `subcategory_mismatch` の3種
- `/inspect` Snapshotタブ拡張（P0）- グループ展開時にissueバナー・カテゴリ内訳・記事別カテゴリバッジを表示
- `collect.go`: Google News汎用feedからの不正ソース混入を `allowedSources` フィルタで除外

## Test plan

- [x] `/inspect` → Snapshot タブ → グループ展開で issue バッジが表示されること
- [x] カテゴリ混在グループで「カテゴリが N 種類混在」の警告が出ること
- [ ] `GET /api/batch/inspect?snapshotId=X&groupId=Y` が詳細JSONを返すこと
- [ ] 存在しない groupId で 404 が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)