### PR TITLE
feat(grouping): カテゴリ制約付きクラスタリング導入（Step 1）

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -72,7 +72,8 @@ RssArticle                            ProcessedSnapshot
 
 - 直近3日以内のembedding済み記事を取得
 - **グリーディコサイン類似度クラスタリング**（閾値: `GROUP_CLUSTER_THRESHOLD`）
-- 異カテゴリ間はスコアに0.7倍のペナルティ
+- **同一カテゴリのクラスタにしか参加できない**（hard gate）
+- unknown カテゴリ（`""` または `"other"`）は例外レーン扱いで、unknown同士のみ結合可（閾値 +0.05）
 - embeddingなし記事は単独クラスタ扱い
 
 ### 5. name

--- a/backend/internal/pipeline/group.go
+++ b/backend/internal/pipeline/group.go
@@ -6,15 +6,35 @@ import (
 	"github.com/newsprism/batch/internal/db"
 )
 
+const (
+	categoryOther                  = "other"
+	unknownCategoryThresholdOffset = 0.05
+)
+
 // Cluster represents a group of articles with a centroid embedding.
 type Cluster struct {
 	Centroid []float32
 	Articles []db.Article
-	DomCat   string
+	DomCate  string
+}
+
+func isUnknownCategory(cat string) bool {
+	return cat == "" || cat == categoryOther
+}
+
+// canJoinCluster reports whether an article with articleCate may join a cluster with clusterCate.
+// Known categories require exact match; unknown categories ("" or "other") may only join each other.
+func canJoinCluster(articleCate, clusterCate string) bool {
+	if isUnknownCategory(articleCate) || isUnknownCategory(clusterCate) {
+		return isUnknownCategory(articleCate) && isUnknownCategory(clusterCate)
+	}
+	return articleCate == clusterCate
 }
 
 // GroupArticles performs greedy cosine similarity clustering.
 // Articles without embeddings are placed in single-article clusters.
+// Articles may only join clusters with the same category (hard gate).
+// Unknown categories ("" or "other") require a higher similarity threshold.
 func GroupArticles(articles []db.Article, threshold float64) []Cluster {
 	var clusters []Cluster
 
@@ -22,22 +42,25 @@ func GroupArticles(articles []db.Article, threshold float64) []Cluster {
 		if len(a.Embedding) == 0 {
 			clusters = append(clusters, Cluster{
 				Articles: []db.Article{a},
-				DomCat:   a.Category,
+				DomCate:  a.Category,
 			})
 			continue
 		}
 
-		bestIdx, bestSim := -1, threshold
+		localThreshold := threshold
+		if isUnknownCategory(a.Category) {
+			localThreshold = threshold + unknownCategoryThresholdOffset
+		}
+
+		bestIdx, bestSim := -1, localThreshold
 		for i, c := range clusters {
 			if len(c.Centroid) == 0 {
 				continue
 			}
-			sim := float64(cosineSim(a.Embedding, c.Centroid))
-			// Soft penalty for cross-category matches
-			if a.Category != "" && a.Category != "other" &&
-				c.DomCat != "other" && a.Category != c.DomCat {
-				sim *= 0.7
+			if !canJoinCluster(a.Category, c.DomCate) {
+				continue
 			}
+			sim := float64(cosineSimilarity(a.Embedding, c.Centroid))
 			if sim > bestSim {
 				bestIdx, bestSim = i, sim
 			}
@@ -45,20 +68,20 @@ func GroupArticles(articles []db.Article, threshold float64) []Cluster {
 
 		if bestIdx >= 0 {
 			clusters[bestIdx].Articles = append(clusters[bestIdx].Articles, a)
-			clusters[bestIdx].Centroid = meanVec(articleVecs(clusters[bestIdx].Articles))
-			clusters[bestIdx].DomCat = dominantCat(clusters[bestIdx].Articles)
+			clusters[bestIdx].Centroid = meanVector(articleVectors(clusters[bestIdx].Articles))
+			clusters[bestIdx].DomCate = dominantCate(clusters[bestIdx].Articles)
 		} else {
 			clusters = append(clusters, Cluster{
 				Centroid: a.Embedding,
 				Articles: []db.Article{a},
-				DomCat:   a.Category,
+				DomCate:  a.Category,
 			})
 		}
 	}
 	return clusters
 }
 
-func cosineSim(a, b []float32) float32 {
+func cosineSimilarity(a, b []float32) float32 {
 	if len(a) != len(b) {
 		return 0
 	}
@@ -74,40 +97,44 @@ func cosineSim(a, b []float32) float32 {
 	return float32(dot / (math.Sqrt(normA) * math.Sqrt(normB)))
 }
 
-func meanVec(vecs [][]float32) []float32 {
-	if len(vecs) == 0 {
+func meanVector(vectors [][]float32) []float32 {
+	if len(vectors) == 0 {
 		return nil
 	}
-	dim := len(vecs[0])
+	dim := len(vectors[0])
 	result := make([]float32, dim)
-	for _, v := range vecs {
+	for _, v := range vectors {
 		for i := range v {
 			result[i] += v[i]
 		}
 	}
-	n := float32(len(vecs))
+	n := float32(len(vectors))
 	for i := range result {
 		result[i] /= n
 	}
 	return result
 }
 
-func articleVecs(articles []db.Article) [][]float32 {
-	vecs := make([][]float32, 0, len(articles))
+func articleVectors(articles []db.Article) [][]float32 {
+	vectors := make([][]float32, 0, len(articles))
 	for _, a := range articles {
 		if len(a.Embedding) > 0 {
-			vecs = append(vecs, a.Embedding)
+			vectors = append(vectors, a.Embedding)
 		}
 	}
-	return vecs
+	return vectors
 }
 
-func dominantCat(articles []db.Article) string {
+func dominantCate(articles []db.Article) string {
 	counts := make(map[string]int)
 	for _, a := range articles {
-		counts[a.Category]++
+		cat := a.Category
+		if isUnknownCategory(cat) {
+			cat = categoryOther
+		}
+		counts[cat]++
 	}
-	best, bestN := "other", 0
+	best, bestN := categoryOther, 0
 	for cat, n := range counts {
 		if n > bestN {
 			best, bestN = cat, n

--- a/backend/internal/pipeline/group_test.go
+++ b/backend/internal/pipeline/group_test.go
@@ -1,0 +1,113 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/newsprism/batch/internal/db"
+)
+
+func vector(v ...float32) []float32 { return v }
+
+// nearVector returns a vector close to base but slightly different.
+func nearVector(base []float32) []float32 {
+	out := make([]float32, len(base))
+	copy(out, base)
+	out[0] += 0.001
+	return out
+}
+
+func makeArticle(category string, embedding []float32) db.Article {
+	return db.Article{Category: category, Embedding: embedding}
+}
+
+// Case 1: 同一カテゴリ → 1 cluster に merge される
+func TestGroupArticles_SameCategory(t *testing.T) {
+	v := vector(1, 0, 0)
+	articles := []db.Article{
+		makeArticle("politics", v),
+		makeArticle("politics", nearVector(v)),
+	}
+	clusters := GroupArticles(articles, 0.87)
+	if len(clusters) != 1 {
+		t.Errorf("want 1 cluster, got %d", len(clusters))
+	}
+}
+
+// Case 2: 異カテゴリ → 2 clusters に分かれる
+func TestGroupArticles_DifferentCategory(t *testing.T) {
+	v := vector(1, 0, 0)
+	articles := []db.Article{
+		makeArticle("politics", v),
+		makeArticle("economy", nearVector(v)),
+	}
+	clusters := GroupArticles(articles, 0.87)
+	if len(clusters) != 2 {
+		t.Errorf("want 2 clusters, got %d", len(clusters))
+	}
+}
+
+// Case 3: other と既知カテゴリ → 2 clusters
+func TestGroupArticles_OtherVsKnown(t *testing.T) {
+	v := vector(1, 0, 0)
+	articles := []db.Article{
+		makeArticle("other", v),
+		makeArticle("politics", nearVector(v)),
+	}
+	clusters := GroupArticles(articles, 0.87)
+	if len(clusters) != 2 {
+		t.Errorf("want 2 clusters, got %d", len(clusters))
+	}
+}
+
+// Case 4: unknown 同士 → 高閾値を超えれば 1 cluster
+func TestGroupArticles_UnknownMerge(t *testing.T) {
+	// 完全に同じベクトルなら similarity=1.0 → unknown 閾値 (0.87+0.05=0.92) を超える
+	v := vector(1, 0, 0)
+	articles := []db.Article{
+		makeArticle("other", v),
+		makeArticle("other", v),
+	}
+	clusters := GroupArticles(articles, 0.87)
+	if len(clusters) != 1 {
+		t.Errorf("want 1 cluster, got %d", len(clusters))
+	}
+}
+
+// Case 5: embedding なし → 単独 cluster
+func TestGroupArticles_NoEmbedding(t *testing.T) {
+	v := vector(1, 0, 0)
+	articles := []db.Article{
+		makeArticle("politics", nil),
+		makeArticle("politics", v),
+	}
+	clusters := GroupArticles(articles, 0.87)
+	if len(clusters) != 2 {
+		t.Errorf("want 2 clusters (no-embed article is solo), got %d", len(clusters))
+	}
+}
+
+// Case 6: 空カテゴリは unknown 扱い → 既知カテゴリと merge されない
+func TestGroupArticles_EmptyCategoryVsKnown(t *testing.T) {
+	v := vector(1, 0, 0)
+	articles := []db.Article{
+		makeArticle("", v),
+		makeArticle("politics", nearVector(v)),
+	}
+	clusters := GroupArticles(articles, 0.87)
+	if len(clusters) != 2 {
+		t.Errorf("want 2 clusters, got %d", len(clusters))
+	}
+}
+
+// Case 7: 空カテゴリ同士は高閾値を超えれば merge される
+func TestGroupArticles_EmptyCategoryMerge(t *testing.T) {
+	v := vector(1, 0, 0)
+	articles := []db.Article{
+		makeArticle("", v),
+		makeArticle("", v),
+	}
+	clusters := GroupArticles(articles, 0.87)
+	if len(clusters) != 1 {
+		t.Errorf("want 1 cluster, got %d", len(clusters))
+	}
+}

--- a/backend/internal/pipeline/name.go
+++ b/backend/internal/pipeline/name.go
@@ -93,7 +93,7 @@ func nameChunk(ctx context.Context, chatClient *llm.ChatClient, clusters []Clust
 
 	var clusterList strings.Builder
 	for i, c := range clusters {
-		cat := dominantCat(c.Articles)
+		cat := dominantCate(c.Articles)
 		titleParts := make([]string, 0, len(c.Articles))
 		for _, a := range c.Articles {
 			titleParts = append(titleParts, "「"+a.Title+"」")

--- a/backend/internal/pipeline/store.go
+++ b/backend/internal/pipeline/store.go
@@ -102,7 +102,7 @@ func Store(ctx context.Context, pool *db.Pool, clusters []Cluster, titles []stri
 
 		groups[i] = db.SnapshotGroup{
 			GroupTitle:   r.title,
-			Category:     r.cluster.DomCat,
+			Category:     r.cluster.DomCate,
 			Rank:         i + 1,
 			SingleOutlet: r.singleOutlet,
 			CoveredBy:    r.sources,


### PR DESCRIPTION
## Summary

- 異カテゴリ混入を防ぐ hard gate を grouping に追加
- soft penalty (`sim *= 0.7`) を廃止し、カテゴリ不一致クラスタを similarity 比較対象から除外
- unknown カテゴリ (`""` / `"other"`) は専用レーンとして扱い、閾値を +0.05 に設定
- `group_test.go` を新規追加（7ケース）

## Test plan

- [x] `go test ./internal/pipeline/` が全パス
- [x] バッチを1回流し `/inspect` で新 snapshot を確認
- [x] `cross_category_mismatch` 件数が旧 snapshot より減少していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)