### PR TITLE
feat(classify): embedding→LLM カスケード分類器に刷新

### DIFF
--- a/backend/internal/llm/chat.go
+++ b/backend/internal/llm/chat.go
@@ -45,7 +45,30 @@ func (c *ChatClient) Complete(ctx context.Context, system, user string) (string,
 	if err != nil {
 		return "", fmt.Errorf("marshal chat request: %w", err)
 	}
+	return c.doRequest(ctx, body)
+}
 
+// CompleteJSON sends a chat completion request with JSON response format.
+// Use for structured classification tasks (temperature=0.1).
+func (c *ChatClient) CompleteJSON(ctx context.Context, system, user string) (string, error) {
+	body, err := json.Marshal(map[string]any{
+		"model": c.Model,
+		"messages": []Message{
+			{Role: "system", Content: system},
+			{Role: "user", Content: user},
+		},
+		"stream":          false,
+		"temperature":     0.1,
+		"max_tokens":      2048,
+		"response_format": map[string]string{"type": "json_object"},
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal chat request: %w", err)
+	}
+	return c.doRequest(ctx, body)
+}
+
+func (c *ChatClient) doRequest(ctx context.Context, body []byte) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, "POST", c.BaseURL+"/v1/chat/completions", bytes.NewReader(body))
 	if err != nil {
 		return "", err

--- a/backend/internal/llm/embed.go
+++ b/backend/internal/llm/embed.go
@@ -27,8 +27,15 @@ func NewEmbedClient(baseURL, model string) *EmbedClient {
 const embedChunkSize = 32
 
 // EmbedBatch vectorizes texts in chunks of embedChunkSize per HTTP request.
+// Uses the document prefix ("文章: ") for article/document embeddings.
 // Returns nil slice elements for failed items.
 func (c *EmbedClient) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	return c.EmbedBatchWithPrefix(ctx, texts, "文章: ")
+}
+
+// EmbedBatchWithPrefix vectorizes texts using the specified prefix.
+// Use "文章: " for documents and "クエリ: " for queries (ruri-v3 asymmetric model).
+func (c *EmbedClient) EmbedBatchWithPrefix(ctx context.Context, texts []string, prefix string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
 	}
@@ -39,7 +46,7 @@ func (c *EmbedClient) EmbedBatch(ctx context.Context, texts []string) ([][]float
 		if r := []rune(t); len(r) > 400 {
 			t = string(r[:400])
 		}
-		prepared[i] = "文章: " + t
+		prepared[i] = prefix + t
 	}
 
 	vecs := make([][]float32, len(texts))

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -34,8 +34,9 @@ func Run(ctx context.Context, pool *db.Pool, cfg config.Config, feeds []config.F
 	}
 	defer db.ReleasePipelineLock(ctx, pool)
 
-	embedClient := llm.NewEmbedClient(cfg.EmbedBaseURL, cfg.EmbedModel)
-	chatClient := llm.NewChatClient(cfg.LLMBaseURL, cfg.LLMModel)
+	embedClient   := llm.NewEmbedClient(cfg.EmbedBaseURL, cfg.EmbedModel)
+	chatClient    := llm.NewChatClient(cfg.LLMBaseURL, cfg.LLMModel)
+	classifyClient := llm.NewChatClient(cfg.LLMBaseURL, cfg.ClassifyModel)
 
 	// 1. collect
 	slog.Info("pipeline: collect start", "feeds", len(feeds))
@@ -53,7 +54,7 @@ func Run(ctx context.Context, pool *db.Pool, cfg config.Config, feeds []config.F
 
 	// 3. classify
 	slog.Info("pipeline: classify start")
-	if err := steps.Classify(ctx, pool); err != nil {
+	if err := steps.Classify(ctx, pool, embedClient, classifyClient, cfg.EmbedClassifyThreshold); err != nil {
 		slog.Error("classify failed", "err", err)
 		return partialResult(start, "classify failed: "+err.Error())
 	}

--- a/backend/internal/pipeline/steps/classify.go
+++ b/backend/internal/pipeline/steps/classify.go
@@ -2,73 +2,217 @@ package steps
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
+	"math"
 	"strings"
+	"sync"
 
 	"github.com/newsprism/batch/internal/db"
+	"github.com/newsprism/batch/internal/llm"
+	"github.com/newsprism/batch/internal/taxonomy"
 )
 
-// Phase A: keyword-based classification (no LLM required).
-// Phase B: replace with embedding → LLM cascade.
+// Phase A: embedding-based classification (fast, ~100ms/article)
+// Phase B: LLM fallback for low-confidence articles
+// Phase C: keyword fallback if LLM fails
+
+// ── 参照 embedding キャッシュ ────────────────────────────────────────────────
+
+type subRef struct {
+	categoryID    string
+	subcategoryID string
+	vec           []float32
+}
+
+var (
+	refOnce sync.Once
+	refVecs []subRef
+	refErr  error
+)
+
+func loadRefEmbeddings(ctx context.Context, embedClient *llm.EmbedClient) ([]subRef, error) {
+	refOnce.Do(func() {
+		subs := taxonomy.AllSubcategoryTexts()
+		texts := make([]string, len(subs))
+		for i, s := range subs {
+			texts[i] = s.Text
+		}
+		// サブカテゴリ説明はドキュメント側（"文章: " プレフィックス）
+		vecs, err := embedClient.EmbedBatchWithPrefix(ctx, texts, "文章: ")
+		if err != nil {
+			refErr = fmt.Errorf("reference embedding failed: %w", err)
+			return
+		}
+		refs := make([]subRef, 0, len(subs))
+		for i, s := range subs {
+			if i < len(vecs) && vecs[i] != nil {
+				refs = append(refs, subRef{
+					categoryID:    s.CategoryID,
+					subcategoryID: s.SubcategoryID,
+					vec:           vecs[i],
+				})
+			}
+		}
+		refVecs = refs
+	})
+	return refVecs, refErr
+}
+
+// ── コサイン類似度 ────────────────────────────────────────────────────────────
+
+func cosineSim(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}
+
+func pickBestRef(vec []float32, refs []subRef) (subRef, float64) {
+	var best subRef
+	bestSim := -1.0
+	for _, r := range refs {
+		s := cosineSim(vec, r.vec)
+		if s > bestSim {
+			bestSim = s
+			best = r
+		}
+	}
+	return best, bestSim
+}
+
+// ── LLM 分類 ─────────────────────────────────────────────────────────────────
+
+var systemPrompt = fmt.Sprintf(`あなたはニュース分類の専門家です。
+与えられたニュース記事を以下の分類基準に基づいて正確に分類してください。
+
+%s
+
+## ルール
+- 必ずJSON形式のみで回答する（説明文不要）
+- category と subcategory は英語IDを使用する
+- confidence は 0.0〜1.0 で回答する`, taxonomy.BuildClassificationGuide())
+
+type llmResult struct {
+	Category    string  `json:"category"`
+	Subcategory string  `json:"subcategory"`
+	Confidence  float64 `json:"confidence"`
+}
+
+type llmBatchResult struct {
+	Results []struct {
+		Index       int     `json:"index"`
+		Category    string  `json:"category"`
+		Subcategory string  `json:"subcategory"`
+		Confidence  float64 `json:"confidence"`
+	} `json:"results"`
+}
+
+func classifyBatchLLM(ctx context.Context, chatClient *llm.ChatClient, articles []db.Article) []llmResult {
+	validCats := taxonomy.ValidCategoryIDs()
+
+	lines := make([]string, len(articles))
+	for i, a := range articles {
+		text := a.Title
+		if a.Summary != "" {
+			sum := a.Summary
+			if len([]rune(sum)) > 80 {
+				sum = string([]rune(sum)[:80])
+			}
+			text += " - " + sum
+		}
+		lines[i] = fmt.Sprintf("%d: 「%s」", i, text)
+	}
+	userMsg := fmt.Sprintf("以下の%d件の記事を分類してください。\n\n%s", len(articles), strings.Join(lines, "\n"))
+
+	raw, err := chatClient.CompleteJSON(ctx, systemPrompt, userMsg)
+	if err != nil {
+		slog.Warn("classify LLM batch failed", "err", err)
+		return nil
+	}
+
+	var batch llmBatchResult
+	if jsonErr := json.Unmarshal([]byte(raw), &batch); jsonErr != nil {
+		slog.Warn("classify LLM batch parse failed", "err", jsonErr, "raw", raw[:min(len(raw), 200)])
+		return nil
+	}
+
+	resultMap := make(map[int]llmResult, len(batch.Results))
+	for _, r := range batch.Results {
+		cat := r.Category
+		if !validCats[cat] {
+			cat = classifyByKeyword(articles[r.Index].Title + " " + articles[r.Index].Summary)
+		}
+		sub := r.Subcategory
+		if !taxonomy.ValidSubcategoryID(cat, sub) {
+			sub = taxonomy.FirstSubcategoryID(cat)
+		}
+		resultMap[r.Index] = llmResult{Category: cat, Subcategory: sub, Confidence: r.Confidence}
+	}
+
+	results := make([]llmResult, len(articles))
+	for i, a := range articles {
+		if r, ok := resultMap[i]; ok {
+			results[i] = r
+		} else {
+			// LLM がこのインデックスを返さなかった
+			cat := classifyByKeyword(a.Title + " " + a.Summary)
+			results[i] = llmResult{Category: cat, Subcategory: taxonomy.FirstSubcategoryID(cat)}
+		}
+	}
+	return results
+}
+
+// ── キーワードフォールバック ──────────────────────────────────────────────────
+// カテゴリ名は新 taxonomy（8カテゴリ）に統一
 
 var categoryKeywords = map[string][]string{
 	"politics": {
 		"政府", "首相", "大臣", "国会", "議員", "与党", "野党", "自民党", "立憲", "公明党",
 		"維新", "共産党", "選挙", "投票", "政策", "法案", "閣議", "内閣", "官房長官",
+		"外交", "防衛", "外務省", "NATO", "国連", "G7", "G20", "制裁", "条約", "首脳会談",
+		"中国", "ロシア", "アメリカ", "米国", "韓国", "北朝鮮", "台湾",
 	},
 	"economy": {
 		"経済", "GDP", "物価", "インフレ", "日銀", "金利", "財政", "予算",
-		"株価", "円", "貿易", "賃金", "雇用", "失業", "景気",
-	},
-	"international": {
-		"外交", "防衛", "外務省", "中国", "ロシア", "アメリカ", "米国", "NATO",
-		"国連", "ウクライナ", "台湾", "韓国", "北朝鮮", "G7", "G20", "制裁",
-	},
-	"society": {
-		"社会", "教育", "医療", "福祉", "少子化", "人口", "犯罪", "事件",
-		"事故", "災害", "地域", "生活", "住宅",
-	},
-	"science_tech": {
-		"技術", "AI", "宇宙", "研究", "開発", "特許", "データ", "デジタル",
-		"半導体", "量子", "ロボット", "自動運転",
-	},
-	"environment": {
-		"環境", "気候", "温暖化", "CO2", "再生可能", "エネルギー", "原発", "脱炭素",
-		"カーボン", "排出",
+		"株価", "円", "貿易", "賃金", "雇用", "失業", "景気", "為替",
 	},
 	"business": {
 		"企業", "業績", "売上", "M&A", "上場", "倒産", "リストラ", "決算",
-		"株式", "経営", "投資",
+		"株式", "経営", "投資", "スタートアップ", "IPO",
 	},
-	"culture": {
-		"文化", "スポーツ", "映画", "音楽", "芸術", "観光", "食", "エンタメ",
+	"health": {
+		"医療", "病院", "感染", "ウイルス", "ワクチン", "薬", "治療", "健康",
+		"介護", "医師", "看護", "公衆衛生", "厚生労働",
 	},
-}
-
-// Classify assigns category/subcategory to unclassified articles using keyword matching.
-func Classify(ctx context.Context, pool *db.Pool) error {
-	articles, err := db.GetUnclassifiedArticles(ctx, pool)
-	if err != nil {
-		return err
-	}
-	if len(articles) == 0 {
-		slog.Info("classify: no articles to classify")
-		return nil
-	}
-
-	entries := make([]struct{ URL, Category, Subcategory string }, 0, len(articles))
-	for _, a := range articles {
-		category := classifyByKeyword(a.Title + " " + a.Summary)
-		entries = append(entries, struct{ URL, Category, Subcategory string }{
-			URL: a.URL, Category: category, Subcategory: "",
-		})
-	}
-
-	if err := db.SaveClassifications(ctx, pool, entries); err != nil {
-		return err
-	}
-	slog.Info("classify done", "classified", len(entries))
-	return nil
+	"disaster": {
+		"地震", "津波", "台風", "豪雨", "大雪", "暴風", "原発", "避難",
+		"災害", "警報", "震度", "マグニチュード", "火災", "事故",
+	},
+	"sports": {
+		"野球", "サッカー", "オリンピック", "パラリンピック", "Jリーグ", "NPB",
+		"テニス", "バスケ", "相撲", "格闘技", "競技", "選手", "試合",
+	},
+	"science_tech": {
+		"技術", "AI", "宇宙", "研究", "開発", "特許", "データ", "デジタル",
+		"半導体", "量子", "ロボット", "自動運転", "環境", "気候", "温暖化",
+		"再生可能", "エネルギー", "脱炭素", "カーボン", "EV", "サイバー",
+	},
+	"culture_lifestyle": {
+		"文化", "映画", "音楽", "芸術", "観光", "食", "エンタメ", "芸能",
+		"教育", "学校", "受験", "社会問題", "少子化", "ジェンダー", "犯罪",
+		"詐欺", "裁判", "事件",
+	},
 }
 
 func classifyByKeyword(text string) string {
@@ -85,4 +229,129 @@ func classifyByKeyword(text string) string {
 		}
 	}
 	return best
+}
+
+// ── メインの Classify ─────────────────────────────────────────────────────────
+
+// Classify assigns category/subcategory to unclassified articles using:
+// 1. Embedding cosine similarity classification (fast)
+// 2. LLM fallback for low-confidence results
+// 3. Keyword fallback if LLM fails
+func Classify(ctx context.Context, pool *db.Pool, embedClient *llm.EmbedClient, chatClient *llm.ChatClient, threshold float64) error {
+	articles, err := db.GetUnclassifiedArticles(ctx, pool)
+	if err != nil {
+		return err
+	}
+	if len(articles) == 0 {
+		slog.Info("classify: no articles to classify")
+		return nil
+	}
+
+	refs, err := loadRefEmbeddings(ctx, embedClient)
+	if err != nil {
+		slog.Warn("classify: reference embedding unavailable, falling back to keywords", "err", err)
+		refs = nil
+	}
+
+	type classifyResult struct {
+		url         string
+		category    string
+		subcategory string
+	}
+
+	results := make([]classifyResult, len(articles))
+	var llmBatch []int // インデックス: embedding 信頼度不足で LLM に回すもの
+
+	// Phase A: embedding 分類
+	if len(refs) > 0 {
+		texts := make([]string, len(articles))
+		for i, a := range articles {
+			text := a.Title
+			if a.Summary != "" {
+				text += "\n" + a.Summary
+			}
+			texts[i] = text
+		}
+		// 記事はクエリ側（"クエリ: " プレフィックス）
+		vecs, embedErr := embedClient.EmbedBatchWithPrefix(ctx, texts, "クエリ: ")
+		if embedErr != nil {
+			slog.Warn("classify: article embedding failed, falling back to keywords", "err", embedErr)
+			vecs = nil
+		}
+
+		for i, a := range articles {
+			var vec []float32
+			if vecs != nil && i < len(vecs) {
+				vec = vecs[i]
+			}
+			if vec == nil {
+				cat := classifyByKeyword(a.Title + " " + a.Summary)
+				results[i] = classifyResult{url: a.URL, category: cat, subcategory: taxonomy.FirstSubcategoryID(cat)}
+				continue
+			}
+			best, sim := pickBestRef(vec, refs)
+			if sim >= threshold {
+				results[i] = classifyResult{url: a.URL, category: best.categoryID, subcategory: best.subcategoryID}
+			} else {
+				llmBatch = append(llmBatch, i)
+			}
+		}
+	} else {
+		// 参照 embedding なし → 全件キーワード
+		for i, a := range articles {
+			cat := classifyByKeyword(a.Title + " " + a.Summary)
+			results[i] = classifyResult{url: a.URL, category: cat, subcategory: taxonomy.FirstSubcategoryID(cat)}
+		}
+	}
+
+	// Phase B: LLM フォールバック
+	if len(llmBatch) > 0 && chatClient != nil {
+		batchArticles := make([]db.Article, len(llmBatch))
+		for j, idx := range llmBatch {
+			batchArticles[j] = articles[idx]
+		}
+		llmResults := classifyBatchLLM(ctx, chatClient, batchArticles)
+
+		for j, idx := range llmBatch {
+			if llmResults != nil && j < len(llmResults) {
+				r := llmResults[j]
+				results[idx] = classifyResult{url: articles[idx].URL, category: r.Category, subcategory: r.Subcategory}
+			} else {
+				// Phase C: キーワードフォールバック
+				cat := classifyByKeyword(articles[idx].Title + " " + articles[idx].Summary)
+				results[idx] = classifyResult{url: articles[idx].URL, category: cat, subcategory: taxonomy.FirstSubcategoryID(cat)}
+			}
+		}
+	} else if len(llmBatch) > 0 {
+		for _, idx := range llmBatch {
+			cat := classifyByKeyword(articles[idx].Title + " " + articles[idx].Summary)
+			results[idx] = classifyResult{url: articles[idx].URL, category: cat, subcategory: taxonomy.FirstSubcategoryID(cat)}
+		}
+	}
+
+	entries := make([]struct{ URL, Category, Subcategory string }, len(results))
+	for i, r := range results {
+		entries[i] = struct{ URL, Category, Subcategory string }{
+			URL:         r.url,
+			Category:    r.category,
+			Subcategory: r.subcategory,
+		}
+	}
+
+	if err := db.SaveClassifications(ctx, pool, entries); err != nil {
+		return err
+	}
+	slog.Info("classify done",
+		"total", len(articles),
+		"embedding", len(articles)-len(llmBatch),
+		"llm", len(llmBatch),
+	)
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/backend/internal/taxonomy/taxonomy.go
+++ b/backend/internal/taxonomy/taxonomy.go
@@ -1,0 +1,182 @@
+// Package taxonomy defines the canonical news category/subcategory taxonomy.
+// This mirrors src/lib/config/news-taxonomy-configs.ts exactly.
+package taxonomy
+
+import "fmt"
+
+type Subcategory struct {
+	ID          string
+	Label       string
+	Description string
+}
+
+type Category struct {
+	ID            string
+	Label         string
+	Description   string
+	Subcategories []Subcategory
+}
+
+var Categories = []Category{
+	{
+		ID:          "politics",
+		Label:       "政治",
+		Description: "政権運営、国会、選挙、外交、防衛、安全保障",
+		Subcategories: []Subcategory{
+			{ID: "domestic_politics", Label: "国内政局", Description: "政権運営、党内政治、内閣改造"},
+			{ID: "election", Label: "選挙", Description: "国政選挙、地方選挙、選挙制度"},
+			{ID: "legislation", Label: "立法", Description: "国会審議、法案、条例"},
+			{ID: "diplomacy", Label: "外交", Description: "国家間の交渉、条約、首脳会談、国際会議"},
+			{ID: "security", Label: "安全保障", Description: "防衛政策、自衛隊、軍事、同盟"},
+		},
+	},
+	{
+		ID:          "economy",
+		Label:       "経済",
+		Description: "金融政策、財政、物価、貿易、雇用などマクロ経済",
+		Subcategories: []Subcategory{
+			{ID: "monetary_policy", Label: "金融政策", Description: "日銀政策、金利、量的緩和"},
+			{ID: "fiscal_policy", Label: "財政", Description: "予算、税制、社会保障財源"},
+			{ID: "prices", Label: "物価・消費", Description: "インフレ、デフレ、個人消費"},
+			{ID: "trade", Label: "貿易", Description: "輸出入、為替、国際経済"},
+			{ID: "labor", Label: "労働市場", Description: "雇用統計、賃金、最低賃金"},
+		},
+	},
+	{
+		ID:          "business",
+		Label:       "ビジネス",
+		Description: "個別企業の決算、M&A、スタートアップなど企業動向",
+		Subcategories: []Subcategory{
+			{ID: "earnings", Label: "企業決算", Description: "業績発表、配当、上場企業の財務"},
+			{ID: "ma", Label: "M&A・再編", Description: "合併、買収、経営統合"},
+			{ID: "startup", Label: "スタートアップ", Description: "ベンチャー企業、起業、IPO"},
+			{ID: "hr", Label: "雇用・人事", Description: "採用、リストラ、役員人事"},
+		},
+	},
+	{
+		ID:          "health",
+		Label:       "健康",
+		Description: "医療、感染症、公衆衛生、医療制度",
+		Subcategories: []Subcategory{
+			{ID: "infectious_disease", Label: "感染症", Description: "COVID-19、インフルエンザ、その他感染症"},
+			{ID: "healthcare_system", Label: "医療制度", Description: "健康保険、介護制度、医療政策"},
+			{ID: "pharma", Label: "創薬・治療", Description: "新薬承認、臨床試験、治療法開発"},
+			{ID: "public_health", Label: "公衆衛生", Description: "予防接種、健康寿命、公衆衛生施策"},
+		},
+	},
+	{
+		ID:          "disaster",
+		Label:       "災害",
+		Description: "地震、台風、豪雨、原発事故などの自然・人為災害",
+		Subcategories: []Subcategory{
+			{ID: "earthquake", Label: "地震・津波", Description: "地震、余震、津波"},
+			{ID: "weather_disaster", Label: "気象災害", Description: "台風、豪雨、大雪、暴風"},
+			{ID: "industrial_accident", Label: "原発・産業事故", Description: "原発事故、産業事故、化学事故"},
+			{ID: "disaster_prevention", Label: "防災", Description: "防災対策、避難、警報"},
+		},
+	},
+	{
+		ID:          "sports",
+		Label:       "スポーツ",
+		Description: "野球、サッカー、オリンピックなどの競技スポーツ",
+		Subcategories: []Subcategory{
+			{ID: "baseball", Label: "プロ野球", Description: "NPB、日本シリーズ、選手動向"},
+			{ID: "soccer", Label: "サッカー", Description: "Jリーグ、W杯、ACL"},
+			{ID: "international_sports", Label: "五輪・国際大会", Description: "オリンピック、パラリンピック、世界選手権"},
+			{ID: "other_sports", Label: "その他競技", Description: "テニス、バスケ、相撲、格闘技など"},
+		},
+	},
+	{
+		ID:          "science_tech",
+		Label:       "科学・技術",
+		Description: "AI、半導体、宇宙開発、エネルギー、サイバーセキュリティ",
+		Subcategories: []Subcategory{
+			{ID: "ai_semiconductor", Label: "AI・半導体", Description: "生成AI、LLM、半導体、量子コンピュータ"},
+			{ID: "space", Label: "宇宙", Description: "宇宙開発、ロケット、惑星探査"},
+			{ID: "energy", Label: "エネルギー", Description: "再生可能エネルギー、脱炭素、EV"},
+			{ID: "cyber", Label: "サイバーセキュリティ", Description: "サイバー攻撃、情報漏洩、セキュリティ対策"},
+		},
+	},
+	{
+		ID:          "culture_lifestyle",
+		Label:       "文化・ライフスタイル",
+		Description: "エンタメ、教育、社会問題、事件・司法",
+		Subcategories: []Subcategory{
+			{ID: "entertainment", Label: "エンタメ", Description: "映画、音楽、ドラマ、アニメ、芸能"},
+			{ID: "education", Label: "教育", Description: "教育制度、受験、学習"},
+			{ID: "social_issues", Label: "社会問題", Description: "少子化、高齢化、ジェンダー、人権、格差"},
+			{ID: "crime_justice", Label: "事件・司法", Description: "殺人、詐欺、裁判、法務"},
+		},
+	},
+}
+
+type SubcategoryRef struct {
+	CategoryID    string
+	SubcategoryID string
+	Text          string
+}
+
+// AllSubcategoryTexts returns flattened (categoryID, subcategoryID, text) tuples
+// for use as reference embeddings. Text = "{cat.Label} {sub.Label}: {sub.Description}".
+func AllSubcategoryTexts() []SubcategoryRef {
+	refs := make([]SubcategoryRef, 0, 33)
+	for _, cat := range Categories {
+		for _, sub := range cat.Subcategories {
+			refs = append(refs, SubcategoryRef{
+				CategoryID:    cat.ID,
+				SubcategoryID: sub.ID,
+				Text:          fmt.Sprintf("%s %s: %s", cat.Label, sub.Label, sub.Description),
+			})
+		}
+	}
+	return refs
+}
+
+// BuildClassificationGuide returns a system prompt section listing all categories
+// and subcategories for LLM classification.
+func BuildClassificationGuide() string {
+	guide := ""
+	for _, cat := range Categories {
+		guide += fmt.Sprintf("## %s（%s）\n", cat.Label, cat.ID)
+		for _, sub := range cat.Subcategories {
+			guide += fmt.Sprintf("  - %s（%s）: %s\n", sub.Label, sub.ID, sub.Description)
+		}
+		guide += "\n"
+	}
+	return guide
+}
+
+// ValidCategoryIDs returns a set of valid category ID strings.
+func ValidCategoryIDs() map[string]bool {
+	m := make(map[string]bool, len(Categories))
+	for _, cat := range Categories {
+		m[cat.ID] = true
+	}
+	return m
+}
+
+// ValidSubcategoryID reports whether subcategoryID belongs to categoryID.
+func ValidSubcategoryID(categoryID, subcategoryID string) bool {
+	for _, cat := range Categories {
+		if cat.ID != categoryID {
+			continue
+		}
+		for _, sub := range cat.Subcategories {
+			if sub.ID == subcategoryID {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// FirstSubcategoryID returns the first subcategory ID for a category, or "".
+func FirstSubcategoryID(categoryID string) string {
+	for _, cat := range Categories {
+		if cat.ID == categoryID && len(cat.Subcategories) > 0 {
+			return cat.Subcategories[0].ID
+		}
+	}
+	return ""
+}

--- a/docs/classify-improvement-plan-2026-04-10.md
+++ b/docs/classify-improvement-plan-2026-04-10.md
@@ -1,0 +1,98 @@
+# Go バッチ カテゴリ分類の改善
+
+## Context
+
+Go バッチの `classify.go` はキーワードマッチのみで分類しており精度が低い。
+`GroupArticles` はカテゴリ完全一致のハードゲートを持つため、誤分類 → 同一トピックが別グループに分断される。
+さらに Go 側のカテゴリ名（international, society, environment, culture）と Next.js 側の正式taxonomy（politics, economy, business, health, disaster, sports, science_tech, culture_lifestyle）がズレている。
+
+Next.js 側には既に **embedding→LLM カスケード分類器** (`news-classifier-llm.ts`) が動作しているので、同じロジックを Go に移植する。
+
+## 方針
+
+TS 実装と同じカスケード: **embedding 類似度分類 → LLM フォールバック → キーワードフォールバック**
+
+### embedding プレフィックスについて
+
+ruri-v3-310m は非対称モデル：
+- 参照（サブカテゴリ説明）→ `"文章: "` (DOC)
+- 記事テキスト → `"クエリ: "` (QUERY)
+
+これは TS 実装と同じ。DB に保存済みの embedding は DOC プレフィックスだが、分類には QUERY プレフィックスが必要なため、**分類時に再 embed が必要**（TS 版も同じ）。参照 embedding はパイプライン起動時に1回だけ生成しキャッシュ。
+
+## 変更ファイル
+
+### 1. `backend/internal/taxonomy/taxonomy.go`（新規）
+
+`news-taxonomy-configs.ts` と同一の 8 カテゴリ定義を Go 構造体で定義。
+
+```go
+type Subcategory struct { ID, Label, Description string }
+type Category struct { ID, Label, Description string; Subcategories []Subcategory }
+var Categories = []Category{...}  // 8カテゴリ
+func AllSubcategoryTexts() []struct{ CategoryID, SubcategoryID, Text string }
+func BuildClassificationGuide() string  // LLMプロンプト用
+func ValidCategoryIDs() map[string]bool
+```
+
+### 2. `backend/internal/llm/embed.go`（修正）
+
+prefix を指定可能にする：
+
+```go
+func (c *EmbedClient) EmbedBatchWithPrefix(ctx, texts []string, prefix string) ([][]float32, error)
+```
+
+既存の `EmbedBatch` は内部で `EmbedBatchWithPrefix(ctx, texts, "文章: ")` を呼ぶラッパーに変更。
+
+### 3. `backend/internal/llm/chat.go`（修正）
+
+JSON 応答用メソッドを追加：
+
+```go
+func (c *ChatClient) CompleteJSON(ctx, system, user string) (string, error)
+// temperature=0.1, response_format=json_object
+```
+
+### 4. `backend/internal/pipeline/steps/classify.go`（書き換え）
+
+シグネチャ変更：
+```go
+func Classify(ctx context.Context, pool *db.Pool, embedClient *llm.EmbedClient, chatClient *llm.ChatClient, threshold float64) error
+```
+
+ロジック：
+1. `sync.Once` で参照 embedding 生成（`embedClient.EmbedBatchWithPrefix(ctx, texts, "文章: ")`）
+2. `GetUnclassifiedArticles` で未分類記事取得（title + summary あり）
+3. 記事テキストを `"クエリ: "` プレフィックスで batch embed
+4. 各記事の embedding と全参照 embedding のコサイン類似度を計算、最良マッチ取得
+5. `sim >= threshold`(0.5) → その category/subcategory を採用
+6. 閾値未満 → LLM バッチ分類にエスカレーション
+7. LLM 失敗 → キーワードフォールバック（カテゴリ名を新 taxonomy に更新）
+8. `SaveClassifications` で保存
+
+キーワードマップも新8カテゴリに更新（international→politics, society→culture_lifestyle, environment→science_tech, culture→culture_lifestyle に再編）。
+
+### 5. `backend/internal/pipeline/pipeline.go`（修正）
+
+```go
+classifyClient := llm.NewChatClient(cfg.LLMBaseURL, cfg.ClassifyModel)
+steps.Classify(ctx, pool, embedClient, classifyClient, cfg.EmbedClassifyThreshold)
+```
+
+## 変更しないもの
+
+- `group.go`: カテゴリ名が統一されれば `canJoinCluster` の exact match はそのまま正しく機能する
+- `store.go`, `name.go`: 変更不要
+- DB スキーマ: 変更不要（既存の category/subcategory カラムに新しい値が入るだけ）
+
+## 検証
+
+1. `go build ./...` でビルド確認
+2. `go test ./internal/pipeline/steps/...` — 既存 group テストが通ること
+3. classify 用のユニットテスト追加：
+   - embedding 分類で正しいカテゴリが返ること（モック embed client）
+   - 閾値未満で LLM にフォールバックすること
+   - LLM 失敗時にキーワードフォールバックすること
+4. 実際にバッチ実行し、`snapshot_group_items` のカテゴリが新taxonomy に準拠していること
+5. inspect 画面で cross_category_mismatch の減少を確認


### PR DESCRIPTION
## Summary

- `taxonomy.go` 新規追加: Next.js の `news-taxonomy-configs.ts` と同一の 8 カテゴリ定義を Go 実装
- `embed.go` 修正: `EmbedBatchWithPrefix` でプレフィックス指定に対応（ruri-v3 非対称モデル: 参照=`文章:`, 記事=`クエリ:`）
- `chat.go` 修正: `CompleteJSON` メソッド追加（JSON 構造化出力、temperature=0.1）
- `classify.go` 書き換え: キーワードのみ分類 → **embedding→LLM→キーワード カスケード**
  - Phase A: サブカテゴリ参照 embedding との cosine 類似度（threshold=0.5）で高速分類
  - Phase B: 閾値未満の記事を LLM バッチ分類にフォールバック
  - Phase C: LLM 失敗時はキーワードフォールバック（8カテゴリ対応済み）
- `pipeline.go` 修正: `classifyClient` を追加し `Classify` に渡す

### 解決する問題

`GroupArticles` はカテゴリ完全一致をハードゲートとして使うため、誤分類された記事は同一トピックでも別グループに分断されていた。また Go 側カテゴリ名（international, society 等）と Next.js taxonomy（politics, culture_lifestyle 等）の不一致もグループ分断を引き起こしていた。

## Test plan

- [x] `go build ./...` 成功
- [x] `go test ./internal/pipeline/steps/...` 通過
- [ ] バッチ実行後、`snapshot_group_items` のカテゴリが新 taxonomy（8カテゴリ）に準拠していること
- [ ] inspect 画面で cross_category_mismatch の減少を確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)