### PR TITLE
test: Phase1 ユニットテスト実装（純粋ロジック・外部依存なし）

### DIFF
--- a/server/TEST_PLAN.md
+++ b/server/TEST_PLAN.md
@@ -1,0 +1,202 @@
+# server/ テスト計画
+
+## 概要
+
+現在テストファイルはゼロ。外部依存（DB・LLM API・外部HTTP）が多いため、**純粋ロジックのユニットテスト → httptest によるハンドラテスト → モックサーバーによる統合テスト** の順に進める。
+
+---
+
+## Phase 1: 純粋ロジック（外部依存なし）
+
+最も費用対効果が高い。モック不要で即実装可能。
+
+### 1-1. `internal/rss/filter_test.go` — FilterByKeyword
+
+| ケース | 入力 | 期待 |
+|:--|:--|:--|
+| 空キーワード | `keyword=""`, items 3件 | 全件返却 |
+| タイトル一致 | `keyword="経済"`, Title に「経済」含む item | 1件マッチ |
+| Description 一致 | `keyword="政策"`, Description に含む | マッチ |
+| 大文字小文字無視 | `keyword="ABC"`, Title="abc news" | マッチ |
+| マッチなし | 無関係な items | 空スライス |
+| nil items | `items=nil` | nil 返却 |
+
+### 1-2. `internal/grouper/grouper_test.go` — groupGreedy + ヘルパー
+
+`groupGreedy` は unexported だが同パッケージからテスト可能。
+
+| 関数 | ケース |
+|:--|:--|
+| `groupGreedy` | embedding なし記事 → 各記事が独立クラスタ |
+| `groupGreedy` | 同一ベクトル2記事 (threshold=0.8) → 1クラスタに統合 |
+| `groupGreedy` | 直交ベクトル2記事 → 別クラスタ |
+| `groupGreedy` | カテゴリゲート: 異カテゴリは sim 高くても別クラスタ |
+| `groupGreedy` | セントロイド増分更新の正確性（3記事追加後の centroid 検証） |
+| `isSingleOutlet` | 同一 Source → true |
+| `isSingleOutlet` | 異なる Source → false |
+| `isSingleOutlet` | 1件 → true |
+| `dominantCategory` | 最多カテゴリが返る |
+| `dominantSubcategory` | 空文字除外して最多が返る |
+| `fallbackTitle` | 20文字超 → 切り詰め |
+| `fallbackTitle` | 空 Articles → "無題" |
+
+### 1-3. `shared/db/helpers_test.go` — CosineSimilarity, MeanVector, parseVectorStr
+
+| 関数 | ケース |
+|:--|:--|
+| `CosineSimilarity` | 同一ベクトル → 1.0 |
+| `CosineSimilarity` | 直交 → 0.0 |
+| `CosineSimilarity` | 逆方向 → -1.0 |
+| `CosineSimilarity` | 長さ不一致 → 0 |
+| `CosineSimilarity` | 空スライス → 0 |
+| `MeanVector` | 2ベクトルの平均 |
+| `MeanVector` | 空入力 → nil |
+| `parseVectorStr` | `"[1.0,2.0,3.0]"` → `[]float32{1,2,3}` |
+| `parseVectorStr` | 空文字 → nil |
+
+### 1-4. `internal/rss/parser_test.go` — LoadFeeds
+
+| ケース | 入力 | 期待 |
+|:--|:--|:--|
+| 正常YAML | tmpfile に feeds YAML | FeedConfig スライス |
+| 不正YAML | 壊れた YAML | error |
+| 存在しないパス | `/nonexistent` | error |
+
+### 1-5. `internal/classifier/classifier_test.go` — truncate
+
+| ケース | 入力 | 期待 |
+|:--|:--|:--|
+| 短い文字列 | len < max | そのまま |
+| 日本語切り詰め | 400文字以上 | rune 単位で max |
+
+### 1-6. `internal/middleware/cors_test.go`
+
+| ケース | 期待 |
+|:--|:--|
+| OPTIONS → 204 | レスポンスヘッダに CORS 系3ヘッダ |
+| GET → next 呼出 | CORS ヘッダ付きで next に委譲 |
+
+---
+
+## Phase 2: ハンドラテスト（httptest + モック依存）
+
+`Deps` の各フィールドをモック化して `httptest.NewRecorder` でテスト。
+
+### モック戦略
+
+LLM/DB は具象型（`*llm.ChatClient`, `*db.Pool`）のため、**httptest.NewServer で偽 LLM API を立てる** or **インターフェース抽出** が必要。
+
+**推奨: httptest.NewServer による偽 LLM サーバー**
+- `llm.NewChatClient("http://localhost:XXXX", "test-model")` で差し替え可能（インターフェース変更不要）
+- DB は `pgxpool` なので testcontainers-go or スキップ
+
+### 2-1. `internal/handler/classify_test.go`
+
+| ケース | 入力 | 期待 |
+|:--|:--|:--|
+| 正常リクエスト | `{"title":"テスト","summary":"..."}` | 200 + ClassificationResult JSON |
+| title 空 | `{"title":""}` | 400 "title is required" |
+| 不正 JSON | `{broken` | 400 "invalid request" |
+| LLM エラー | 偽サーバーが 500 返却 | 500 |
+
+### 2-2. `internal/handler/analyze_test.go`
+
+| ケース | 入力 | 期待 |
+|:--|:--|:--|
+| 正常（single model） | title + content (≥10文字) | 200 + analysis JSON |
+| content 短すぎ | len(content) < 10 | 400 |
+| title 空 | `{"title":""}` | 400 |
+
+### 2-3. `internal/handler/batch_test.go`
+
+| ケース | 期待 |
+|:--|:--|
+| `BatchRun` — 偽 batch サーバー 200 | `{"ok": true}` |
+| `BatchRun` — 偽 batch サーバー 500 | 502 |
+| `BatchRun` — 偽 batch サーバー接続不可 | 502 |
+| `BatchInspect` — id 未指定 | 400 |
+
+### 2-4. `internal/handler/rss_test.go`
+
+| ケース | 期待 |
+|:--|:--|
+| feedUrl 未指定 | 400 |
+
+### 2-5. `internal/handler/history_test.go`
+
+| ケース | 期待 |
+|:--|:--|
+| `HistorySimilar` — limit 未指定 | デフォルト 10 適用 |
+| `HistorySimilar` — limit > 100 | 100 に制限 |
+| `HistorySimilar` — 不正 JSON | 400 |
+
+### 2-6. `internal/handler/helpers_test.go`
+
+| 関数 | ケース |
+|:--|:--|
+| `writeJSON` | Content-Type: application/json, ボディ検証 |
+| `writeError` | ステータスコード + error JSON |
+
+### 2-7. `internal/handler/register_test.go`
+
+| ケース | 期待 |
+|:--|:--|
+| 全ルート登録確認 | 各パスに GET/POST でリクエスト → 404 でないこと |
+
+---
+
+## Phase 3: 統合テスト（DB + 偽 LLM）
+
+`testcontainers-go` で PostgreSQL + pgvector コンテナを起動。
+
+### 3-1. `internal/scraper/fetcher_test.go`
+
+- httptest.NewServer で HTML を返す偽サーバー
+- `<article><p>` あり → 本文抽出
+- `<p>` のみ（50文字超） → 抽出
+- 短い `<p>` のみ → エラー（"could not extract content"）
+
+### 3-2. `internal/sse/writer_test.go`
+
+- httptest.NewRecorder で SSE フォーマット検証
+- `Init()` → Content-Type: text/event-stream
+- `Send("event", data)` → `event: event\ndata: {...}\n\n`
+- `Comment("msg")` → `: msg\n\n`
+
+### 3-3. DB 連携テスト（shared/db）
+
+testcontainers で pgvector 付き PostgreSQL を起動:
+
+| 関数 | ケース |
+|:--|:--|
+| `SaveArticle` → `GetRecentArticles` | 保存→取得ラウンドトリップ |
+| `UpsertArticles` | 重複 URL は UPDATE |
+| `FindSimilarArticles` | ベクトル検索結果の順序 |
+| `SaveEmbeddings` → `GetUnembeddedArticles` | embedded_at 更新確認 |
+| `SaveClassifications` → `GetUnclassifiedArticles` | classified_at 更新確認 |
+
+---
+
+## 実装優先順位
+
+| 順位 | 対象 | 理由 |
+|:--|:--|:--|
+| **1** | Phase 1 全て | 外部依存ゼロ、すぐ書ける、ロジックバグの発見率高い |
+| **2** | Phase 2: helpers, register, classify, history | ハンドラの入力バリデーションは重要 |
+| **3** | Phase 3: scraper, sse | httptest で完結、低コスト |
+| **4** | Phase 3: DB 連携 | testcontainers 導入コストあるが長期的に必須 |
+| **5** | Phase 2: analyze, batch | LLM モック + 非同期処理のテストは複雑 |
+
+---
+
+## テスト実行コマンド
+
+```bash
+cd server && GOCACHE=../.gocache go test ./...
+```
+
+## カバレッジ目標
+
+- Phase 1 完了時: ユーティリティ関数 100%
+- Phase 2 完了時: ハンドラ入力バリデーション 100%、正常系 80%
+- Phase 3 完了時: E2E パス 70%

--- a/server/internal/classifier/classifier_test.go
+++ b/server/internal/classifier/classifier_test.go
@@ -1,0 +1,43 @@
+package classifier
+
+import "testing"
+
+func TestTruncate(t *testing.T) {
+	t.Run("短い文字列はそのまま", func(t *testing.T) {
+		s := "こんにちは"
+		if got := truncate(s, 10); got != s {
+			t.Errorf("got %q, want %q", got, s)
+		}
+	})
+
+	t.Run("ちょうどmax", func(t *testing.T) {
+		s := "あいうえお"
+		if got := truncate(s, 5); got != s {
+			t.Errorf("got %q, want %q", got, s)
+		}
+	})
+
+	t.Run("日本語切り詰め", func(t *testing.T) {
+		s := "あいうえおかきくけこさしすせそ" // 15文字
+		got := truncate(s, 10)
+		if len([]rune(got)) != 10 {
+			t.Errorf("got %d runes, want 10", len([]rune(got)))
+		}
+		if got != "あいうえおかきくけこ" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("ASCII文字列", func(t *testing.T) {
+		s := "hello world"
+		if got := truncate(s, 5); got != "hello" {
+			t.Errorf("got %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("空文字列", func(t *testing.T) {
+		if got := truncate("", 10); got != "" {
+			t.Errorf("got %q, want %q", got, "")
+		}
+	})
+}

--- a/server/internal/grouper/grouper_test.go
+++ b/server/internal/grouper/grouper_test.go
@@ -1,0 +1,174 @@
+package grouper
+
+import (
+	"testing"
+
+	"github.com/newsprism/shared/db"
+)
+
+// --- groupGreedy ---
+
+func TestGroupGreedy_NoEmbedding(t *testing.T) {
+	articles := []db.Article{
+		{URL: "a", Title: "記事A"},
+		{URL: "b", Title: "記事B"},
+	}
+	clusters := groupGreedy(articles, 0.8)
+	if len(clusters) != 2 {
+		t.Fatalf("embedding なし: got %d clusters, want 2", len(clusters))
+	}
+}
+
+func TestGroupGreedy_SameVector(t *testing.T) {
+	vec := []float32{1, 0, 0}
+	articles := []db.Article{
+		{URL: "a", Title: "記事A", Embedding: vec},
+		{URL: "b", Title: "記事B", Embedding: vec},
+	}
+	clusters := groupGreedy(articles, 0.8)
+	if len(clusters) != 1 {
+		t.Fatalf("同一ベクトル: got %d clusters, want 1", len(clusters))
+	}
+	if len(clusters[0].Articles) != 2 {
+		t.Fatalf("got %d articles in cluster, want 2", len(clusters[0].Articles))
+	}
+}
+
+func TestGroupGreedy_OrthogonalVectors(t *testing.T) {
+	articles := []db.Article{
+		{URL: "a", Title: "記事A", Embedding: []float32{1, 0, 0}},
+		{URL: "b", Title: "記事B", Embedding: []float32{0, 1, 0}},
+	}
+	clusters := groupGreedy(articles, 0.8)
+	if len(clusters) != 2 {
+		t.Fatalf("直交ベクトル: got %d clusters, want 2", len(clusters))
+	}
+}
+
+func TestGroupGreedy_CategoryGate(t *testing.T) {
+	// 高類似度でもカテゴリが違えば別クラスタ
+	vec := []float32{1, 0, 0}
+	articles := []db.Article{
+		{URL: "a", Title: "記事A", Embedding: vec, Category: "politics"},
+		{URL: "b", Title: "記事B", Embedding: vec, Category: "sports"},
+	}
+	clusters := groupGreedy(articles, 0.5)
+	if len(clusters) != 2 {
+		t.Fatalf("異カテゴリ: got %d clusters, want 2", len(clusters))
+	}
+}
+
+func TestGroupGreedy_CentroidUpdate(t *testing.T) {
+	// 3記事を同クラスタに追加してセントロイドが平均に収束することを確認
+	v1 := []float32{1, 0, 0}
+	v2 := []float32{1, 0, 0}
+	v3 := []float32{1, 0, 0}
+	articles := []db.Article{
+		{URL: "a", Embedding: v1},
+		{URL: "b", Embedding: v2},
+		{URL: "c", Embedding: v3},
+	}
+	clusters := groupGreedy(articles, 0.5)
+	if len(clusters) != 1 {
+		t.Fatalf("got %d clusters, want 1", len(clusters))
+	}
+	// セントロイドは (1,0,0) のまま
+	c := clusters[0].Centroid
+	if len(c) == 0 || c[0] != 1 {
+		t.Errorf("centroid[0] = %v, want 1", c)
+	}
+}
+
+// --- isSingleOutlet ---
+
+func TestIsSingleOutlet(t *testing.T) {
+	t.Run("1件", func(t *testing.T) {
+		arts := []db.Article{{Source: "NHK"}}
+		if !isSingleOutlet(arts) {
+			t.Error("1件は single outlet")
+		}
+	})
+	t.Run("同一Source", func(t *testing.T) {
+		arts := []db.Article{{Source: "NHK"}, {Source: "NHK"}}
+		if !isSingleOutlet(arts) {
+			t.Error("同一 source は single outlet")
+		}
+	})
+	t.Run("異なるSource", func(t *testing.T) {
+		arts := []db.Article{{Source: "NHK"}, {Source: "朝日"}}
+		if isSingleOutlet(arts) {
+			t.Error("異なる source は not single outlet")
+		}
+	})
+	t.Run("空スライス", func(t *testing.T) {
+		if !isSingleOutlet([]db.Article{}) {
+			t.Error("空は single outlet 扱い")
+		}
+	})
+}
+
+// --- dominantCategory ---
+
+func TestDominantCategory(t *testing.T) {
+	arts := []db.Article{
+		{Category: "politics"},
+		{Category: "sports"},
+		{Category: "politics"},
+	}
+	if got := dominantCategory(arts); got != "politics" {
+		t.Errorf("got %q, want %q", got, "politics")
+	}
+}
+
+func TestDominantCategory_Empty(t *testing.T) {
+	got := dominantCategory([]db.Article{})
+	if got != "other" {
+		t.Errorf("空スライス: got %q, want %q", got, "other")
+	}
+}
+
+// --- dominantSubcategory ---
+
+func TestDominantSubcategory(t *testing.T) {
+	arts := []db.Article{
+		{Subcategory: "tax"},
+		{Subcategory: ""},
+		{Subcategory: "tax"},
+		{Subcategory: "budget"},
+	}
+	if got := dominantSubcategory(arts); got != "tax" {
+		t.Errorf("got %q, want %q", got, "tax")
+	}
+}
+
+func TestDominantSubcategory_AllEmpty(t *testing.T) {
+	arts := []db.Article{{Subcategory: ""}, {Subcategory: ""}}
+	if got := dominantSubcategory(arts); got != "" {
+		t.Errorf("全空: got %q, want %q", got, "")
+	}
+}
+
+// --- fallbackTitle ---
+
+func TestFallbackTitle_Short(t *testing.T) {
+	c := Cluster{Articles: []db.Article{{Title: "短いタイトル"}}}
+	if got := fallbackTitle(c); got != "短いタイトル" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFallbackTitle_Long(t *testing.T) {
+	title := "あいうえおかきくけこさしすせそたちつてとなにぬねの" // 25文字
+	c := Cluster{Articles: []db.Article{{Title: title}}}
+	got := fallbackTitle(c)
+	if len([]rune(got)) != 20 {
+		t.Errorf("got %d runes, want 20", len([]rune(got)))
+	}
+}
+
+func TestFallbackTitle_NoArticles(t *testing.T) {
+	c := Cluster{}
+	if got := fallbackTitle(c); got != "無題" {
+		t.Errorf("got %q, want %q", got, "無題")
+	}
+}

--- a/server/internal/middleware/cors_test.go
+++ b/server/internal/middleware/cors_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORS_OPTIONS(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next should not be called for OPTIONS")
+	})
+	handler := CORS(next)
+
+	req := httptest.NewRequest("OPTIONS", "/api/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != 204 {
+		t.Errorf("got %d, want 204", rec.Code)
+	}
+	checkCORSHeaders(t, rec)
+}
+
+func TestCORS_GET(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(200)
+	})
+	handler := CORS(next)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !nextCalled {
+		t.Error("next handler not called")
+	}
+	if rec.Code != 200 {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+	checkCORSHeaders(t, rec)
+}
+
+func TestCORS_POST(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(201)
+	})
+	handler := CORS(next)
+
+	req := httptest.NewRequest("POST", "/api/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != 201 {
+		t.Errorf("got %d, want 201", rec.Code)
+	}
+	checkCORSHeaders(t, rec)
+}
+
+func checkCORSHeaders(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	h := rec.Header()
+	if h.Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("Access-Control-Allow-Origin: got %q", h.Get("Access-Control-Allow-Origin"))
+	}
+	if h.Get("Access-Control-Allow-Methods") == "" {
+		t.Error("Access-Control-Allow-Methods not set")
+	}
+	if h.Get("Access-Control-Allow-Headers") == "" {
+		t.Error("Access-Control-Allow-Headers not set")
+	}
+}

--- a/server/internal/rss/filter_test.go
+++ b/server/internal/rss/filter_test.go
@@ -1,0 +1,57 @@
+package rss
+
+import (
+	"testing"
+
+	"github.com/mmcdole/gofeed"
+)
+
+func TestFilterByKeyword(t *testing.T) {
+	items := []*gofeed.Item{
+		{Title: "経済政策の行方", Description: "財政に関する話題"},
+		{Title: "スポーツ速報", Description: "野球の試合結果"},
+		{Title: "ABC News", Description: "abc ニュース"},
+	}
+
+	t.Run("空キーワードは全件返す", func(t *testing.T) {
+		got := FilterByKeyword(items, "")
+		if len(got) != len(items) {
+			t.Fatalf("got %d, want %d", len(got), len(items))
+		}
+	})
+
+	t.Run("タイトル一致", func(t *testing.T) {
+		got := FilterByKeyword(items, "経済")
+		if len(got) != 1 || got[0].Title != "経済政策の行方" {
+			t.Fatalf("unexpected: %v", got)
+		}
+	})
+
+	t.Run("Description一致", func(t *testing.T) {
+		got := FilterByKeyword(items, "財政")
+		if len(got) != 1 {
+			t.Fatalf("got %d, want 1", len(got))
+		}
+	})
+
+	t.Run("大文字小文字無視", func(t *testing.T) {
+		got := FilterByKeyword(items, "ABC")
+		if len(got) != 1 || got[0].Title != "ABC News" {
+			t.Fatalf("unexpected: %v", got)
+		}
+	})
+
+	t.Run("マッチなし", func(t *testing.T) {
+		got := FilterByKeyword(items, "存在しないキーワード")
+		if len(got) != 0 {
+			t.Fatalf("got %d, want 0", len(got))
+		}
+	})
+
+	t.Run("nilスライス", func(t *testing.T) {
+		got := FilterByKeyword(nil, "経済")
+		if got != nil {
+			t.Fatalf("got %v, want nil", got)
+		}
+	})
+}

--- a/server/internal/rss/parser_test.go
+++ b/server/internal/rss/parser_test.go
@@ -1,0 +1,71 @@
+package rss
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFeeds(t *testing.T) {
+	t.Run("正常YAML", func(t *testing.T) {
+		content := `
+feeds:
+  - id: nhk
+    name: NHK
+    url: https://example.com/nhk.rss
+  - id: asahi
+    name: 朝日新聞
+    url: https://example.com/asahi.rss
+`
+		f := writeTempFile(t, content)
+		feeds, err := LoadFeeds(f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(feeds) != 2 {
+			t.Fatalf("got %d feeds, want 2", len(feeds))
+		}
+		if feeds[0].ID != "nhk" || feeds[0].Name != "NHK" {
+			t.Errorf("unexpected feed[0]: %+v", feeds[0])
+		}
+	})
+
+	t.Run("不正YAML", func(t *testing.T) {
+		f := writeTempFile(t, "feeds: [broken: :")
+		_, err := LoadFeeds(f)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("存在しないパス", func(t *testing.T) {
+		_, err := LoadFeeds("/nonexistent/path/feeds.yaml")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("feedsキーなし", func(t *testing.T) {
+		f := writeTempFile(t, "other: value\n")
+		feeds, err := LoadFeeds(f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(feeds) != 0 {
+			t.Fatalf("got %d feeds, want 0", len(feeds))
+		}
+	})
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "feeds-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Clean(f.Name())
+}

--- a/shared/db/helpers_test.go
+++ b/shared/db/helpers_test.go
@@ -1,0 +1,114 @@
+package db
+
+import (
+	"math"
+	"testing"
+)
+
+// --- CosineSimilarity ---
+
+func TestCosineSimilarity_Same(t *testing.T) {
+	v := []float32{1, 2, 3}
+	got := CosineSimilarity(v, v)
+	if math.Abs(float64(got)-1.0) > 1e-5 {
+		t.Errorf("same vector: got %v, want ~1.0", got)
+	}
+}
+
+func TestCosineSimilarity_Orthogonal(t *testing.T) {
+	a := []float32{1, 0, 0}
+	b := []float32{0, 1, 0}
+	got := CosineSimilarity(a, b)
+	if math.Abs(float64(got)) > 1e-5 {
+		t.Errorf("orthogonal: got %v, want ~0.0", got)
+	}
+}
+
+func TestCosineSimilarity_Opposite(t *testing.T) {
+	a := []float32{1, 0, 0}
+	b := []float32{-1, 0, 0}
+	got := CosineSimilarity(a, b)
+	if math.Abs(float64(got)+1.0) > 1e-5 {
+		t.Errorf("opposite: got %v, want ~-1.0", got)
+	}
+}
+
+func TestCosineSimilarity_LengthMismatch(t *testing.T) {
+	a := []float32{1, 0}
+	b := []float32{1, 0, 0}
+	got := CosineSimilarity(a, b)
+	if got != 0 {
+		t.Errorf("length mismatch: got %v, want 0", got)
+	}
+}
+
+func TestCosineSimilarity_Empty(t *testing.T) {
+	got := CosineSimilarity(nil, nil)
+	if got != 0 {
+		t.Errorf("empty: got %v, want 0", got)
+	}
+}
+
+// --- MeanVector ---
+
+func TestMeanVector_Two(t *testing.T) {
+	a := []float32{1, 0}
+	b := []float32{0, 1}
+	got := MeanVector([][]float32{a, b})
+	if len(got) != 2 || math.Abs(float64(got[0])-0.5) > 1e-5 || math.Abs(float64(got[1])-0.5) > 1e-5 {
+		t.Errorf("got %v, want [0.5, 0.5]", got)
+	}
+}
+
+func TestMeanVector_Empty(t *testing.T) {
+	got := MeanVector(nil)
+	if got != nil {
+		t.Errorf("empty: got %v, want nil", got)
+	}
+}
+
+func TestMeanVector_Single(t *testing.T) {
+	v := []float32{3, 6, 9}
+	got := MeanVector([][]float32{v})
+	for i, val := range got {
+		if math.Abs(float64(val)-float64(v[i])) > 1e-5 {
+			t.Errorf("single vector: got[%d]=%v, want %v", i, val, v[i])
+		}
+	}
+}
+
+// --- parseVectorStr ---
+
+func TestParseVectorStr_Normal(t *testing.T) {
+	got := parseVectorStr("[1.0,2.0,3.0]")
+	want := []float32{1, 2, 3}
+	if len(got) != len(want) {
+		t.Fatalf("got len %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if math.Abs(float64(got[i])-float64(want[i])) > 1e-5 {
+			t.Errorf("[%d]: got %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseVectorStr_Empty(t *testing.T) {
+	got := parseVectorStr("[]")
+	if got != nil {
+		t.Errorf("empty brackets: got %v, want nil", got)
+	}
+}
+
+func TestParseVectorStr_EmptyString(t *testing.T) {
+	got := parseVectorStr("")
+	if got != nil {
+		t.Errorf("empty string: got %v, want nil", got)
+	}
+}
+
+func TestParseVectorStr_Spaces(t *testing.T) {
+	got := parseVectorStr("[1.0, 2.0, 3.0]")
+	if len(got) != 3 {
+		t.Fatalf("got len %d, want 3", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

- `server/TEST_PLAN.md` にテスト計画書（Phase1〜3）を追加
- Phase1（外部依存ゼロ）の43テストを全パスする形で実装

## 対象パッケージ・テスト数

| パッケージ | テスト数 |
|:--|:--|
| `server/internal/rss` | 10 |
| `server/internal/grouper` | 13 |
| `server/internal/classifier` | 5 |
| `server/internal/middleware` | 3 |
| `shared/db` | 12 |
| **合計** | **43** |

## Test plan

- [x] `go test ./internal/rss/... ./internal/grouper/... ./internal/classifier/... ./internal/middleware/...` — 全パス確認
- [x] `go test ./db/...` (shared) — 全パス確認
- [ ] Phase2（httptest + 偽LLMサーバー）は次PR予定
- [ ] Phase3（DB統合テスト）はその後

🤖 Generated with [Claude Code](https://claude.com/claude-code)