### PR TITLE
test: Phase2 ハンドラテスト実装（httptest + 偽LLMサーバー）

### DIFF
--- a/server/internal/handler/analyze_test.go
+++ b/server/internal/handler/analyze_test.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAnalyze_BadJSON(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("POST", "/api/analyze", strings.NewReader("{bad"))
+	rec := httptest.NewRecorder()
+	d.Analyze(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+}
+
+func TestAnalyze_EmptyTitle(t *testing.T) {
+	d := &Deps{}
+	body := `{"title":"","content":"十分な長さのコンテンツ"}`
+	req := httptest.NewRequest("POST", "/api/analyze", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Analyze(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "invalid data")
+}
+
+func TestAnalyze_ContentTooShort(t *testing.T) {
+	d := &Deps{}
+	body := `{"title":"タイトル","content":"短い"}`
+	req := httptest.NewRequest("POST", "/api/analyze", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Analyze(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "invalid data")
+}
+
+func TestAnalyze_Success_SingleModel(t *testing.T) {
+	// ChatClient が返す分析JSON
+	analysisJSON := `{"economic":0.1,"social":0.0,"diplomatic":-0.2,"emotional_tone":0.0,"bias_warning":false,"summary":"テスト要約","counter_opinion":"反論","confidence":0.8}`
+	chatSrv := fakeLLMServer(t, analysisJSON)
+	defer chatSrv.Close()
+
+	// ClassifyClient が返す分類JSON (classify は error を無視するので不正でもOK)
+	classifyJSON := `{"category":"politics","subcategory":"domestic_politics","confidence":0.8}`
+	classifySrv := fakeLLMServer(t, classifyJSON)
+	defer classifySrv.Close()
+
+	// EmbedClient は非同期goroutineで呼ばれる。失敗させてgoroutineを早期returnさせる。
+	embedSrv := failLLMServer(t)
+	defer embedSrv.Close()
+
+	d := &Deps{
+		ChatClient:     newChatClient(chatSrv),
+		ClassifyClient: newChatClient(classifySrv),
+		EmbedClient:    newEmbedClient(embedSrv),
+		Pool:           nil, // EmbedがエラーになるのでSaveArticleは呼ばれない
+	}
+
+	body := `{"title":"テスト記事タイトル","content":"これは十分な長さのコンテンツです。テスト用の記事本文。"}`
+	req := httptest.NewRequest("POST", "/api/analyze", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Analyze(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("got %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := got["analysis"]; !ok {
+		t.Error("response missing 'analysis' field")
+	}
+	if _, ok := got["category"]; !ok {
+		t.Error("response missing 'category' field")
+	}
+}

--- a/server/internal/handler/batch_test.go
+++ b/server/internal/handler/batch_test.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBatchInspect_MissingID(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("GET", "/api/batch/inspect", nil)
+	rec := httptest.NewRecorder()
+	d.BatchInspect(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "id is required")
+}
+
+func TestBatchInspectRecompute_NotImplemented(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("POST", "/api/batch/inspect/recompute", nil)
+	rec := httptest.NewRecorder()
+	d.BatchInspectRecompute(rec, req)
+
+	if rec.Code != 501 {
+		t.Errorf("got %d, want 501", rec.Code)
+	}
+}
+
+func TestBatchRun_Success(t *testing.T) {
+	batchSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer batchSrv.Close()
+
+	d := &Deps{BatchServerURL: batchSrv.URL}
+	req := httptest.NewRequest("POST", "/api/batch/run", nil)
+	rec := httptest.NewRecorder()
+	d.BatchRun(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+	var got map[string]bool
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got["ok"] {
+		t.Error("expected ok=true")
+	}
+}
+
+func TestBatchRun_BatchServerError(t *testing.T) {
+	batchSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer batchSrv.Close()
+
+	d := &Deps{BatchServerURL: batchSrv.URL}
+	req := httptest.NewRequest("POST", "/api/batch/run", nil)
+	rec := httptest.NewRecorder()
+	d.BatchRun(rec, req)
+
+	if rec.Code != 502 {
+		t.Errorf("got %d, want 502", rec.Code)
+	}
+}
+
+func TestBatchRun_ConnectionRefused(t *testing.T) {
+	// 存在しないURLで接続エラーを起こす
+	d := &Deps{BatchServerURL: "http://127.0.0.1:1"}
+	req := httptest.NewRequest("POST", "/api/batch/run", nil)
+	rec := httptest.NewRecorder()
+	d.BatchRun(rec, req)
+
+	if rec.Code != 502 {
+		t.Errorf("got %d, want 502", rec.Code)
+	}
+}

--- a/server/internal/handler/classify_test.go
+++ b/server/internal/handler/classify_test.go
@@ -1,0 +1,88 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/newsprism/server/internal/classifier"
+)
+
+func TestClassify_BadJSON(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("POST", "/api/classify", strings.NewReader("{broken"))
+	rec := httptest.NewRecorder()
+	d.Classify(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "invalid request")
+}
+
+func TestClassify_EmptyTitle(t *testing.T) {
+	d := &Deps{}
+	body := `{"title":"","summary":"some summary"}`
+	req := httptest.NewRequest("POST", "/api/classify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Classify(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "title is required")
+}
+
+func TestClassify_LLMError(t *testing.T) {
+	srv := failLLMServer(t)
+	defer srv.Close()
+
+	d := &Deps{ClassifyClient: newChatClient(srv)}
+	body := `{"title":"テスト記事","summary":"要約テキスト"}`
+	req := httptest.NewRequest("POST", "/api/classify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Classify(rec, req)
+
+	if rec.Code != 500 {
+		t.Errorf("got %d, want 500", rec.Code)
+	}
+}
+
+func TestClassify_Success(t *testing.T) {
+	classifyJSON := `{"category":"politics","subcategory":"domestic_politics","confidence":0.9}`
+	srv := fakeLLMServer(t, classifyJSON)
+	defer srv.Close()
+
+	d := &Deps{ClassifyClient: newChatClient(srv)}
+	body := `{"title":"国会で審議中の法案について","summary":"与野党が対立"}`
+	req := httptest.NewRequest("POST", "/api/classify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Classify(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+	var result classifier.ClassificationResult
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Category != "politics" {
+		t.Errorf("category: got %q, want %q", result.Category, "politics")
+	}
+	if result.Subcategory != "domestic_politics" {
+		t.Errorf("subcategory: got %q, want %q", result.Subcategory, "domestic_politics")
+	}
+}
+
+// assertErrorBody は {"error":"..."} のボディ検証ヘルパー。
+func assertErrorBody(t *testing.T, rec *httptest.ResponseRecorder, contains string) {
+	t.Helper()
+	var got map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if !strings.Contains(got["error"], contains) {
+		t.Errorf("error body: got %q, want contains %q", got["error"], contains)
+	}
+}

--- a/server/internal/handler/helpers_test.go
+++ b/server/internal/handler/helpers_test.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeJSON(rec, map[string]string{"key": "value"})
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "application/json")
+	}
+	var got map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["key"] != "value" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeError(rec, "something went wrong", 422)
+
+	if rec.Code != 422 {
+		t.Errorf("status: got %d, want 422", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "application/json")
+	}
+	var got map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["error"] != "something went wrong" {
+		t.Errorf("error field: got %q", got["error"])
+	}
+}

--- a/server/internal/handler/history_test.go
+++ b/server/internal/handler/history_test.go
@@ -1,0 +1,19 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHistorySimilar_BadJSON(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("POST", "/api/history/similar", strings.NewReader("{bad"))
+	rec := httptest.NewRecorder()
+	d.HistorySimilar(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "invalid request")
+}

--- a/server/internal/handler/register_test.go
+++ b/server/internal/handler/register_test.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/newsprism/shared/config"
+)
+
+// safeRoutes は DB/LLM なしで安全に呼べるルートと期待ステータス。
+var safeRoutes = []struct {
+	method string
+	path   string
+	want   int
+}{
+	{"GET", "/api/config", 200},
+	{"POST", "/api/batch/inspect/recompute", 501},
+	{"GET", "/api/batch/inspect", 400},     // id 未指定 → 400
+	{"GET", "/api/rss", 400},               // feedUrl 未指定 → 400
+	{"GET", "/api/youtube/feed", 200},
+	{"POST", "/api/classify", 400},         // 空ボディ → 400
+	{"POST", "/api/fetch-article", 400},    // 不正ボディ → 400
+	{"POST", "/api/youtube/analyze", 400},  // 空ボディ → 400
+}
+
+func TestRegister_SafeRoutes(t *testing.T) {
+	mux := http.NewServeMux()
+	d := &Deps{Config: config.SharedConfig{LLMModel: "test"}}
+	Register(mux, d)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := srv.Client()
+	for _, tt := range safeRoutes {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, srv.URL+tt.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode == 404 {
+				t.Errorf("route not registered: %s %s → 404", tt.method, tt.path)
+			}
+			if resp.StatusCode != tt.want {
+				t.Errorf("got %d, want %d", resp.StatusCode, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/handler/rss_test.go
+++ b/server/internal/handler/rss_test.go
@@ -1,0 +1,18 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRSS_MissingFeedURL(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("GET", "/api/rss", nil)
+	rec := httptest.NewRecorder()
+	d.RSS(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "feedUrl is required")
+}

--- a/server/internal/handler/testutil_test.go
+++ b/server/internal/handler/testutil_test.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/newsprism/shared/llm"
+)
+
+// fakeLLMServer は /v1/chat/completions に対して content を返す偽 LLM サーバーを作る。
+func fakeLLMServer(t *testing.T, content string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": content}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// failLLMServer は常に 500 を返す偽サーバーを作る。
+func failLLMServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, "internal error")
+	}))
+}
+
+// newChatClient は httptest.Server のURLを使った ChatClient を返す。
+func newChatClient(s *httptest.Server) *llm.ChatClient {
+	return llm.NewChatClient(s.URL, "test-model")
+}
+
+// newEmbedClient は httptest.Server のURLを使った EmbedClient を返す。
+func newEmbedClient(s *httptest.Server) *llm.EmbedClient {
+	return llm.NewEmbedClient(s.URL, "test-model")
+}


### PR DESCRIPTION
## Summary

- `server/internal/handler/` の全ハンドラに対してテストを追加
- DB不要な入力バリデーション + `httptest.NewServer` による偽LLMサーバーを活用

## 追加テスト一覧

| ファイル | テスト数 | 概要 |
|:--|:--|:--|
| `testutil_test.go` | — | 偽LLMサーバー・失敗サーバーヘルパー |
| `helpers_test.go` | 2 | writeJSON / writeError |
| `classify_test.go` | 4 | バリデーション2 + LLMエラー + 成功 |
| `analyze_test.go` | 4 | バリデーション3 + 成功（偽LLM2台） |
| `batch_test.go` | 4 | 400 / 501 / BatchRun成功・失敗・接続不可 |
| `rss_test.go` | 1 | feedUrl未指定 → 400 |
| `history_test.go` | 1 | 不正JSON → 400 |
| `register_test.go` | 8 | 安全な8ルートの登録確認 |

**Phase1(43) + Phase2(25) = 累計68テスト全パス**

## モック戦略

- LLM依存: `httptest.NewServer` で偽 `/v1/chat/completions` を立てて `llm.NewChatClient(srv.URL, ...)` に差し替え（インターフェース変更不要）
- 非同期embed goroutine: 失敗サーバーを使い `Embed` をエラー終了させてPoolへのアクセスを回避
- DB依存ハンドラ: 入力バリデーションのみをテスト対象（Pool依存パスはPhase3予定）

## Test plan

- [x] `go test ./internal/handler/... -timeout 30s` — 全パス確認
- [ ] `HistorySimilar` のlimit上限テストはPhase3（DB統合）で実施予定
- [ ] DB依存ハンドラの正常系はPhase3で実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)