### PR TITLE
feat: 未実装Go APIハンドラの実装 + inspect修正

### DIFF
--- a/server/internal/handler/analyze_test.go
+++ b/server/internal/handler/analyze_test.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAnalyze_BadJSON(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("POST", "/api/analyze", strings.NewReader("{bad"))
+	rec := httptest.NewRecorder()
+	d.Analyze(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+}
+
+func TestAnalyze_EmptyTitle(t *testing.T) {
+	d := &Deps{}
+	body := `{"title":"","content":"十分な長さのコンテンツ"}`
+	req := httptest.NewRequest("POST", "/api/analyze", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Analyze(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "invalid data")
+}
+
+func TestAnalyze_ContentTooShort(t *testing.T) {
+	d := &Deps{}
+	body := `{"title":"タイトル","content":"短い"}`
+	req := httptest.NewRequest("POST", "/api/analyze", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Analyze(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "invalid data")
+}
+
+func TestAnalyze_Success_SingleModel(t *testing.T) {
+	// ChatClient が返す分析JSON
+	analysisJSON := `{"economic":0.1,"social":0.0,"diplomatic":-0.2,"emotional_tone":0.0,"bias_warning":false,"summary":"テスト要約","counter_opinion":"反論","confidence":0.8}`
+	chatSrv := fakeLLMServer(t, analysisJSON)
+	defer chatSrv.Close()
+
+	// ClassifyClient が返す分類JSON (classify は error を無視するので不正でもOK)
+	classifyJSON := `{"category":"politics","subcategory":"domestic_politics","confidence":0.8}`
+	classifySrv := fakeLLMServer(t, classifyJSON)
+	defer classifySrv.Close()
+
+	// EmbedClient は非同期goroutineで呼ばれる。失敗させてgoroutineを早期returnさせる。
+	embedSrv := failLLMServer(t)
+	defer embedSrv.Close()
+
+	d := &Deps{
+		ChatClient:     newChatClient(chatSrv),
+		ClassifyClient: newChatClient(classifySrv),
+		EmbedClient:    newEmbedClient(embedSrv),
+		Pool:           nil, // EmbedがエラーになるのでSaveArticleは呼ばれない
+	}
+
+	body := `{"title":"テスト記事タイトル","content":"これは十分な長さのコンテンツです。テスト用の記事本文。"}`
+	req := httptest.NewRequest("POST", "/api/analyze", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Analyze(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("got %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := got["analysis"]; !ok {
+		t.Error("response missing 'analysis' field")
+	}
+	if _, ok := got["category"]; !ok {
+		t.Error("response missing 'category' field")
+	}
+}

--- a/server/internal/handler/batch.go
+++ b/server/internal/handler/batch.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 
@@ -49,9 +50,9 @@ func (d *Deps) BatchRun(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *Deps) BatchInspect(w http.ResponseWriter, r *http.Request) {
-	id := r.URL.Query().Get("id")
+	id := r.URL.Query().Get("groupId")
 	if id == "" {
-		writeError(w, "id is required", 400)
+		writeError(w, "groupId is required", 400)
 		return
 	}
 	group, err := db.GetSnapshotGroupDetail(r.Context(), d.Pool, id)
@@ -63,6 +64,22 @@ func (d *Deps) BatchInspect(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *Deps) BatchInspectRecompute(w http.ResponseWriter, r *http.Request) {
-	// TODO: implement recompute
-	writeError(w, "Not implemented", 501)
+	var req struct {
+		SnapshotID string `json:"snapshotId"`
+		GroupID    string `json:"groupId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "invalid request", 400)
+		return
+	}
+	if req.GroupID == "" {
+		writeError(w, "groupId is required", 400)
+		return
+	}
+	result, err := db.RecomputeGroupInspect(r.Context(), d.Pool, req.SnapshotID, req.GroupID, d.Config.GroupClusterThreshold)
+	if err != nil {
+		writeError(w, "recompute failed: "+err.Error(), 500)
+		return
+	}
+	writeJSON(w, result)
 }

--- a/server/internal/handler/batch_test.go
+++ b/server/internal/handler/batch_test.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBatchInspect_MissingID(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("GET", "/api/batch/inspect", nil)
+	rec := httptest.NewRecorder()
+	d.BatchInspect(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "id is required")
+}
+
+func TestBatchInspectRecompute_NotImplemented(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("POST", "/api/batch/inspect/recompute", nil)
+	rec := httptest.NewRecorder()
+	d.BatchInspectRecompute(rec, req)
+
+	if rec.Code != 501 {
+		t.Errorf("got %d, want 501", rec.Code)
+	}
+}
+
+func TestBatchRun_Success(t *testing.T) {
+	batchSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer batchSrv.Close()
+
+	d := &Deps{BatchServerURL: batchSrv.URL}
+	req := httptest.NewRequest("POST", "/api/batch/run", nil)
+	rec := httptest.NewRecorder()
+	d.BatchRun(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+	var got map[string]bool
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got["ok"] {
+		t.Error("expected ok=true")
+	}
+}
+
+func TestBatchRun_BatchServerError(t *testing.T) {
+	batchSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer batchSrv.Close()
+
+	d := &Deps{BatchServerURL: batchSrv.URL}
+	req := httptest.NewRequest("POST", "/api/batch/run", nil)
+	rec := httptest.NewRecorder()
+	d.BatchRun(rec, req)
+
+	if rec.Code != 502 {
+		t.Errorf("got %d, want 502", rec.Code)
+	}
+}
+
+func TestBatchRun_ConnectionRefused(t *testing.T) {
+	// 存在しないURLで接続エラーを起こす
+	d := &Deps{BatchServerURL: "http://127.0.0.1:1"}
+	req := httptest.NewRequest("POST", "/api/batch/run", nil)
+	rec := httptest.NewRecorder()
+	d.BatchRun(rec, req)
+
+	if rec.Code != 502 {
+		t.Errorf("got %d, want 502", rec.Code)
+	}
+}

--- a/server/internal/handler/classify_test.go
+++ b/server/internal/handler/classify_test.go
@@ -1,0 +1,88 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/newsprism/server/internal/classifier"
+)
+
+func TestClassify_BadJSON(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("POST", "/api/classify", strings.NewReader("{broken"))
+	rec := httptest.NewRecorder()
+	d.Classify(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "invalid request")
+}
+
+func TestClassify_EmptyTitle(t *testing.T) {
+	d := &Deps{}
+	body := `{"title":"","summary":"some summary"}`
+	req := httptest.NewRequest("POST", "/api/classify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Classify(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "title is required")
+}
+
+func TestClassify_LLMError(t *testing.T) {
+	srv := failLLMServer(t)
+	defer srv.Close()
+
+	d := &Deps{ClassifyClient: newChatClient(srv)}
+	body := `{"title":"テスト記事","summary":"要約テキスト"}`
+	req := httptest.NewRequest("POST", "/api/classify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Classify(rec, req)
+
+	if rec.Code != 500 {
+		t.Errorf("got %d, want 500", rec.Code)
+	}
+}
+
+func TestClassify_Success(t *testing.T) {
+	classifyJSON := `{"category":"politics","subcategory":"domestic_politics","confidence":0.9}`
+	srv := fakeLLMServer(t, classifyJSON)
+	defer srv.Close()
+
+	d := &Deps{ClassifyClient: newChatClient(srv)}
+	body := `{"title":"国会で審議中の法案について","summary":"与野党が対立"}`
+	req := httptest.NewRequest("POST", "/api/classify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.Classify(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+	var result classifier.ClassificationResult
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Category != "politics" {
+		t.Errorf("category: got %q, want %q", result.Category, "politics")
+	}
+	if result.Subcategory != "domestic_politics" {
+		t.Errorf("subcategory: got %q, want %q", result.Subcategory, "domestic_politics")
+	}
+}
+
+// assertErrorBody は {"error":"..."} のボディ検証ヘルパー。
+func assertErrorBody(t *testing.T, rec *httptest.ResponseRecorder, contains string) {
+	t.Helper()
+	var got map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if !strings.Contains(got["error"], contains) {
+		t.Errorf("error body: got %q, want contains %q", got["error"], contains)
+	}
+}

--- a/server/internal/handler/compare.go
+++ b/server/internal/handler/compare.go
@@ -1,11 +1,13 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 
 	"github.com/newsprism/server/internal/grouper"
 	"github.com/newsprism/server/internal/rss"
+	"github.com/newsprism/server/internal/scraper"
 	"github.com/newsprism/shared/db"
 )
 
@@ -40,5 +42,37 @@ func (d *Deps) Compare(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *Deps) CompareAnalyze(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, map[string]string{"status": "todo"})
+	var req struct {
+		Items []struct {
+			Title       string  `json:"title"`
+			URL         string  `json:"url"`
+			Source      string  `json:"source"`
+			PublishedAt *string `json:"publishedAt"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "invalid request", 400)
+		return
+	}
+	if len(req.Items) == 0 {
+		writeError(w, "items is required", 400)
+		return
+	}
+
+	items := make([]SSEAnalyzeItem, len(req.Items))
+	for i, item := range req.Items {
+		content, err := scraper.FetchArticleFromUrl(item.URL)
+		if err != nil || len([]rune(content)) < 10 {
+			content = item.Title
+		}
+		items[i] = SSEAnalyzeItem{
+			Title:       item.Title,
+			URL:         item.URL,
+			Source:      item.Source,
+			PublishedAt: item.PublishedAt,
+			Content:     content,
+		}
+	}
+
+	d.streamAnalyze(w, r, items)
 }

--- a/server/internal/handler/helpers_test.go
+++ b/server/internal/handler/helpers_test.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeJSON(rec, map[string]string{"key": "value"})
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "application/json")
+	}
+	var got map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["key"] != "value" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeError(rec, "something went wrong", 422)
+
+	if rec.Code != 422 {
+		t.Errorf("status: got %d, want 422", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "application/json")
+	}
+	var got map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["error"] != "something went wrong" {
+		t.Errorf("error field: got %q", got["error"])
+	}
+}

--- a/server/internal/handler/history_test.go
+++ b/server/internal/handler/history_test.go
@@ -1,0 +1,19 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHistorySimilar_BadJSON(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("POST", "/api/history/similar", strings.NewReader("{bad"))
+	rec := httptest.NewRecorder()
+	d.HistorySimilar(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "invalid request")
+}

--- a/server/internal/handler/register_test.go
+++ b/server/internal/handler/register_test.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/newsprism/shared/config"
+)
+
+// safeRoutes は DB/LLM なしで安全に呼べるルートと期待ステータス。
+var safeRoutes = []struct {
+	method string
+	path   string
+	want   int
+}{
+	{"GET", "/api/config", 200},
+	{"POST", "/api/batch/inspect/recompute", 501},
+	{"GET", "/api/batch/inspect", 400},     // id 未指定 → 400
+	{"GET", "/api/rss", 400},               // feedUrl 未指定 → 400
+	{"GET", "/api/youtube/feed", 200},
+	{"POST", "/api/classify", 400},         // 空ボディ → 400
+	{"POST", "/api/fetch-article", 400},    // 不正ボディ → 400
+	{"POST", "/api/youtube/analyze", 400},  // 空ボディ → 400
+}
+
+func TestRegister_SafeRoutes(t *testing.T) {
+	mux := http.NewServeMux()
+	d := &Deps{Config: config.SharedConfig{LLMModel: "test"}}
+	Register(mux, d)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := srv.Client()
+	for _, tt := range safeRoutes {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, srv.URL+tt.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode == 404 {
+				t.Errorf("route not registered: %s %s → 404", tt.method, tt.path)
+			}
+			if resp.StatusCode != tt.want {
+				t.Errorf("got %d, want %d", resp.StatusCode, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/handler/rss_test.go
+++ b/server/internal/handler/rss_test.go
@@ -1,0 +1,18 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRSS_MissingFeedURL(t *testing.T) {
+	d := &Deps{}
+	req := httptest.NewRequest("GET", "/api/rss", nil)
+	rec := httptest.NewRecorder()
+	d.RSS(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("got %d, want 400", rec.Code)
+	}
+	assertErrorBody(t, rec, "feedUrl is required")
+}

--- a/server/internal/handler/sse_analyze.go
+++ b/server/internal/handler/sse_analyze.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/newsprism/server/internal/analyzer"
+	"github.com/newsprism/server/internal/sse"
+)
+
+// SSEArticle is the shape sent to the frontend via SSE.
+type SSEArticle struct {
+	Title       string                `json:"title"`
+	URL         string                `json:"url"`
+	Source      string                `json:"source"`
+	PublishedAt *string               `json:"publishedAt,omitempty"`
+	ImageURL    *string               `json:"imageUrl,omitempty"`
+	Content     string                `json:"content"`
+	Analysis    *analyzer.AnalysisResult `json:"analysis"`
+	AnalyzedAt  string                `json:"analyzedAt"`
+}
+
+// SSEAnalyzeItem is a single item to analyze.
+type SSEAnalyzeItem struct {
+	Title       string
+	URL         string
+	Source      string
+	PublishedAt *string
+	ImageURL    *string
+	Content     string // pre-resolved content to analyze
+}
+
+// streamAnalyze runs analyzer.Analyze for each item and streams results via SSE.
+func (d *Deps) streamAnalyze(w http.ResponseWriter, r *http.Request, items []SSEAnalyzeItem) {
+	sw := sse.NewWriter(w)
+	sw.Init()
+
+	for _, item := range items {
+		result, err := analyzer.Analyze(r.Context(), d.ChatClient, item.Title, item.Content)
+		if err != nil {
+			continue
+		}
+
+		art := SSEArticle{
+			Title:       item.Title,
+			URL:         item.URL,
+			Source:      item.Source,
+			PublishedAt: item.PublishedAt,
+			ImageURL:    item.ImageURL,
+			Content:     item.Content,
+			Analysis:    result,
+			AnalyzedAt:  time.Now().Format(time.RFC3339),
+		}
+		sw.Send("article", map[string]any{"article": art}) //nolint:errcheck
+	}
+
+	sw.Send("done", map[string]any{"total": len(items)}) //nolint:errcheck
+}

--- a/server/internal/handler/testutil_test.go
+++ b/server/internal/handler/testutil_test.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/newsprism/shared/llm"
+)
+
+// fakeLLMServer は /v1/chat/completions に対して content を返す偽 LLM サーバーを作る。
+func fakeLLMServer(t *testing.T, content string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": content}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// failLLMServer は常に 500 を返す偽サーバーを作る。
+func failLLMServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, "internal error")
+	}))
+}
+
+// newChatClient は httptest.Server のURLを使った ChatClient を返す。
+func newChatClient(s *httptest.Server) *llm.ChatClient {
+	return llm.NewChatClient(s.URL, "test-model")
+}
+
+// newEmbedClient は httptest.Server のURLを使った EmbedClient を返す。
+func newEmbedClient(s *httptest.Server) *llm.EmbedClient {
+	return llm.NewEmbedClient(s.URL, "test-model")
+}

--- a/server/internal/handler/youtube.go
+++ b/server/internal/handler/youtube.go
@@ -3,21 +3,60 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
+
+	"github.com/newsprism/server/internal/youtube"
 )
 
-type YouTubeAnalyzeRequest struct {
-	VideoIDs []string `json:"videoIds"`
-}
-
 func (d *Deps) YouTubeFeed(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, map[string]string{"status": "not implemented"})
+	raw := r.URL.Query().Get("channels")
+	if raw == "" {
+		writeError(w, "channels is required", 400)
+		return
+	}
+	ids := strings.Split(raw, ",")
+	items := youtube.FetchChannels(r.Context(), ids)
+	if items == nil {
+		items = []youtube.VideoItem{}
+	}
+	writeJSON(w, map[string]any{"items": items})
 }
 
 func (d *Deps) YouTubeAnalyze(w http.ResponseWriter, r *http.Request) {
-	var req YouTubeAnalyzeRequest
+	var req struct {
+		Items []struct {
+			Title       string  `json:"title"`
+			URL         string  `json:"url"`
+			Source      string  `json:"source"`
+			Summary     *string `json:"summary"`
+			PublishedAt *string `json:"publishedAt"`
+			ImageURL    *string `json:"imageUrl"`
+		} `json:"items"`
+	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, "invalid request", 400)
 		return
 	}
-	writeJSON(w, map[string]string{"status": "not implemented"})
+	if len(req.Items) == 0 {
+		writeError(w, "items is required", 400)
+		return
+	}
+
+	items := make([]SSEAnalyzeItem, len(req.Items))
+	for i, item := range req.Items {
+		content := item.Title
+		if item.Summary != nil && len([]rune(*item.Summary)) >= 10 {
+			content = *item.Summary
+		}
+		items[i] = SSEAnalyzeItem{
+			Title:       item.Title,
+			URL:         item.URL,
+			Source:      item.Source,
+			PublishedAt: item.PublishedAt,
+			ImageURL:    item.ImageURL,
+			Content:     content,
+		}
+	}
+
+	d.streamAnalyze(w, r, items)
 }

--- a/server/internal/youtube/feed.go
+++ b/server/internal/youtube/feed.go
@@ -1,0 +1,101 @@
+package youtube
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/mmcdole/gofeed"
+)
+
+type ChannelConfig struct {
+	ID        string
+	Name      string
+	ChannelID string
+	MaxVideos int
+}
+
+// VideoItem matches the frontend RssFeedItem shape.
+type VideoItem struct {
+	Title       string  `json:"title"`
+	URL         string  `json:"url"`
+	Source      string  `json:"source"`
+	Summary     *string `json:"summary,omitempty"`
+	PublishedAt *string `json:"publishedAt,omitempty"`
+	ImageURL    *string `json:"imageUrl,omitempty"`
+}
+
+// AllChannels mirrors src/lib/config/youtube-channel-configs.ts.
+var AllChannels = []ChannelConfig{
+	{ID: "tbsnews", Name: "TBS NEWS DIG", ChannelID: "UC6AG81pAkf6Lbi_1VC5NmPA", MaxVideos: 5},
+	{ID: "annnews", Name: "テレ朝news", ChannelID: "UCGCZAYq5Xxojl_tSXcVJhiQ", MaxVideos: 5},
+	{ID: "ntv", Name: "日テレNEWS", ChannelID: "UCuTAXTexrhetbOe3zgskJBQ", MaxVideos: 5},
+	{ID: "fnn", Name: "FNNプライムオンライン", ChannelID: "UCE_pHCKVR4m16EfSSEaTBJg", MaxVideos: 5},
+	{ID: "pivot", Name: "PIVOT", ChannelID: "UC8yHePe_RgUBE-waRWy6olw", MaxVideos: 5},
+	{ID: "rehacq", Name: "ReHacQ", ChannelID: "UCG_oqDSlIYEspNpd2H4zWhw", MaxVideos: 5},
+	{ID: "bunkahouse", Name: "文化人放送局", ChannelID: "UCCSPJbVEuAGRFDPLPBQRBEg", MaxVideos: 5},
+	{ID: "clp", Name: "Choose Life Project", ChannelID: "UCe7nBCBFVzFDLnM3S7L2V6Q", MaxVideos: 5},
+	{ID: "takahashi", Name: "高橋洋一チャンネル", ChannelID: "UCECfnRv8lSbn90zCAJWC7cg", MaxVideos: 5},
+	{ID: "ichimanmasamitsu", Name: "一月万冊", ChannelID: "UCMirnQIiZsqNHaYXSXFQ17Q", MaxVideos: 5},
+}
+
+// FetchChannels fetches YouTube RSS feeds for the given config IDs in parallel.
+func FetchChannels(ctx context.Context, ids []string) []VideoItem {
+	byID := make(map[string]ChannelConfig, len(AllChannels))
+	for _, c := range AllChannels {
+		byID[c.ID] = c
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var items []VideoItem
+
+	parser := gofeed.NewParser()
+	parser.Client.Timeout = 10 * time.Second
+
+	for _, id := range ids {
+		cfg, ok := byID[id]
+		if !ok {
+			continue
+		}
+		wg.Add(1)
+		go func(cfg ChannelConfig) {
+			defer wg.Done()
+			feedURL := fmt.Sprintf("https://www.youtube.com/feeds/videos.xml?channel_id=%s", cfg.ChannelID)
+			feed, err := parser.ParseURLWithContext(feedURL, ctx)
+			if err != nil {
+				return
+			}
+			limit := cfg.MaxVideos
+			if limit > len(feed.Items) {
+				limit = len(feed.Items)
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, item := range feed.Items[:limit] {
+				vi := VideoItem{
+					Title:  item.Title,
+					URL:    item.Link,
+					Source: cfg.Name,
+				}
+				if item.Description != "" {
+					s := item.Description
+					vi.Summary = &s
+				}
+				if item.PublishedParsed != nil {
+					s := item.PublishedParsed.Format(time.RFC3339)
+					vi.PublishedAt = &s
+				}
+				if item.Image != nil && item.Image.URL != "" {
+					s := item.Image.URL
+					vi.ImageURL = &s
+				}
+				items = append(items, vi)
+			}
+		}(cfg)
+	}
+
+	wg.Wait()
+	return items
+}

--- a/shared/db/articles.go
+++ b/shared/db/articles.go
@@ -239,6 +239,72 @@ func SaveClassifications(ctx context.Context, pool *pgxpool.Pool, entries []stru
 	return nil
 }
 
+// GetEmbeddingsByURLs returns a url→embedding map for the given URLs.
+func GetEmbeddingsByURLs(ctx context.Context, pool *pgxpool.Pool, urls []string) (map[string][]float32, error) {
+	rows, err := pool.Query(ctx, `
+		SELECT url, embedding::text FROM rss_articles
+		WHERE url = ANY($1) AND embedding IS NOT NULL`,
+		urls,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make(map[string][]float32)
+	for rows.Next() {
+		var url, embStr string
+		if err := rows.Scan(&url, &embStr); err != nil {
+			return nil, err
+		}
+		result[url] = parseVectorStr(embStr)
+	}
+	return result, rows.Err()
+}
+
+// SimilarArticleWithGroup is a result of FindSimilarArticlesWithGroup.
+type SimilarArticleWithGroup struct {
+	URL        string
+	Title      string
+	Source     string
+	GroupID    *string
+	GroupTitle *string
+	Similarity float32
+}
+
+// FindSimilarArticlesWithGroup performs a vector search and joins snapshot group info.
+func FindSimilarArticlesWithGroup(ctx context.Context, pool *pgxpool.Pool, embedding []float32, excludeURL string, limit int) ([]SimilarArticleWithGroup, error) {
+	rows, err := pool.Query(ctx, `
+		SELECT a.url, a.title, a.source,
+		       sgi.group_id, sg.group_title,
+		       1 - (a.embedding <=> $1::vector) AS similarity
+		FROM rss_articles a
+		LEFT JOIN LATERAL (
+		    SELECT sgi2.group_id FROM snapshot_group_items sgi2
+		    WHERE sgi2.url = a.url LIMIT 1
+		) sgi ON true
+		LEFT JOIN snapshot_groups sg ON sg.id = sgi.group_id
+		WHERE a.embedding IS NOT NULL
+		  AND a.url != $2
+		  AND a.published_at >= NOW() - INTERVAL '30 days'
+		ORDER BY a.embedding <=> $1::vector
+		LIMIT $3`,
+		pgvector.NewVector(embedding), excludeURL, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var results []SimilarArticleWithGroup
+	for rows.Next() {
+		var a SimilarArticleWithGroup
+		if err := rows.Scan(&a.URL, &a.Title, &a.Source, &a.GroupID, &a.GroupTitle, &a.Similarity); err != nil {
+			return nil, err
+		}
+		results = append(results, a)
+	}
+	return results, rows.Err()
+}
+
 // FindSimilarArticles performs a vector cosine distance search.
 func FindSimilarArticles(ctx context.Context, pool *pgxpool.Pool, embedding []float32, limit int) ([]Article, error) {
 	rows, err := pool.Query(ctx, `

--- a/shared/db/snapshots.go
+++ b/shared/db/snapshots.go
@@ -203,44 +203,255 @@ func GetSnapshotHistory(ctx context.Context, pool *pgxpool.Pool) ([]Snapshot, er
 	return history, nil
 }
 
-func GetSnapshotGroupDetail(ctx context.Context, pool *pgxpool.Pool, groupID string) (*SnapshotGroup, error) {
-	var g SnapshotGroup
+type GroupInspectArticle struct {
+	Title       string  `json:"title"`
+	URL         string  `json:"url"`
+	Source      string  `json:"source"`
+	PublishedAt *string `json:"publishedAt"`
+	Category    *string `json:"category"`
+	Subcategory *string `json:"subcategory"`
+	Summary     *string `json:"summary"`
+}
+
+type GroupIssue struct {
+	Type     string `json:"type"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type GroupInspectSummary struct {
+	TotalArticles int            `json:"totalArticles"`
+	ByCategory    map[string]int `json:"byCategory"`
+	Issues        []GroupIssue   `json:"issues"`
+}
+
+type GroupInspectDetail struct {
+	SnapshotID   string               `json:"snapshotId"`
+	GroupID      string               `json:"groupId"`
+	GroupTitle   string               `json:"groupTitle"`
+	Category     *string              `json:"category"`
+	Subcategory  *string              `json:"subcategory"`
+	Rank         int                  `json:"rank"`
+	SingleOutlet bool                 `json:"singleOutlet"`
+	CoveredBy    []string             `json:"coveredBy"`
+	SilentMedia  []string             `json:"silentMedia"`
+	Articles     []GroupInspectArticle `json:"articles"`
+	Summary      GroupInspectSummary  `json:"summary"`
+}
+
+func GetSnapshotGroupDetail(ctx context.Context, pool *pgxpool.Pool, groupID string) (*GroupInspectDetail, error) {
+	var d GroupInspectDetail
 	var coveredJSON, silentJSON []byte
 	err := pool.QueryRow(ctx, `
-		SELECT id, snapshot_id, group_title, COALESCE(category,''), COALESCE(subcategory,''), rank, single_outlet, covered_by, silent_media
+		SELECT id, snapshot_id, group_title, category, subcategory, rank, single_outlet, covered_by, silent_media
 		FROM snapshot_groups
 		WHERE id = $1`,
 		groupID,
-	).Scan(&g.ID, &g.SnapshotID, &g.GroupTitle, &g.Category, &g.Subcategory, &g.Rank, &g.SingleOutlet, &coveredJSON, &silentJSON)
+	).Scan(&d.GroupID, &d.SnapshotID, &d.GroupTitle, &d.Category, &d.Subcategory, &d.Rank, &d.SingleOutlet, &coveredJSON, &silentJSON)
 	if err != nil {
 		return nil, err
 	}
-	if err := json.Unmarshal(coveredJSON, &g.CoveredBy); err != nil {
+	if err := json.Unmarshal(coveredJSON, &d.CoveredBy); err != nil {
 		return nil, fmt.Errorf("unmarshal covered_by: %w", err)
 	}
-	if err := json.Unmarshal(silentJSON, &g.SilentMedia); err != nil {
+	if err := json.Unmarshal(silentJSON, &d.SilentMedia); err != nil {
 		return nil, fmt.Errorf("unmarshal silent_media: %w", err)
 	}
 
 	itemRows, err := pool.Query(ctx, `
-		SELECT id, title, url, source, COALESCE(summary,''), COALESCE(published_at,''), COALESCE(category,''), COALESCE(subcategory,'')
+		SELECT title, url, source, summary, published_at, category, subcategory
 		FROM snapshot_group_items
 		WHERE group_id = $1`,
-		g.ID,
+		d.GroupID,
 	)
 	if err != nil {
 		return nil, err
 	}
 	defer itemRows.Close()
 
+	byCategory := map[string]int{}
 	for itemRows.Next() {
-		var item SnapshotGroupItem
-		err := itemRows.Scan(&item.ID, &item.Title, &item.URL, &item.Source, &item.Summary, &item.PublishedAt, &item.Category, &item.Subcategory)
-		if err != nil {
+		var a GroupInspectArticle
+		if err := itemRows.Scan(&a.Title, &a.URL, &a.Source, &a.Summary, &a.PublishedAt, &a.Category, &a.Subcategory); err != nil {
 			return nil, err
 		}
-		g.Items = append(g.Items, item)
+		if a.Category != nil {
+			byCategory[*a.Category]++
+		}
+		d.Articles = append(d.Articles, a)
 	}
 
-	return &g, nil
+	d.Summary = GroupInspectSummary{
+		TotalArticles: len(d.Articles),
+		ByCategory:    byCategory,
+		Issues:        []GroupIssue{},
+	}
+
+	return &d, nil
+}
+
+// --- Recompute ---
+
+type RecomputeNeighbor struct {
+	URL        string  `json:"url"`
+	Title      string  `json:"title"`
+	Source     string  `json:"source"`
+	GroupID    string  `json:"groupId"`
+	GroupTitle string  `json:"groupTitle"`
+	Similarity float64 `json:"similarity"`
+}
+
+type RecomputeAlternativeCluster struct {
+	GroupID    string  `json:"groupId"`
+	GroupTitle string  `json:"groupTitle"`
+	Category   *string `json:"category"`
+	Similarity float64 `json:"similarity"`
+}
+
+type RecomputeArticleResult struct {
+	URL                     string                        `json:"url"`
+	Title                   string                        `json:"title"`
+	Source                  string                        `json:"source"`
+	Category                *string                       `json:"category"`
+	HasEmbedding            bool                          `json:"hasEmbedding"`
+	IsUnknownCategory       bool                          `json:"isUnknownCategory"`
+	SimilarityToCentroid    *float64                      `json:"similarityToCentroid"`
+	SimilarityBeforePenalty *float64                      `json:"similarityBeforePenalty"`
+	SimilarityAfterPenalty  *float64                      `json:"similarityAfterPenalty"`
+	WouldJoinAtThreshold    *bool                         `json:"wouldJoinAtThreshold"`
+	NearestNeighbors        []RecomputeNeighbor           `json:"nearestNeighbors"`
+	AlternativeClusters     []RecomputeAlternativeCluster `json:"alternativeClusters"`
+}
+
+type ThresholdSimulation struct {
+	Threshold   float64 `json:"threshold"`
+	WouldStay   int     `json:"wouldStay"`
+	WouldLeave  int     `json:"wouldLeave"`
+	NoEmbedding int     `json:"noEmbedding"`
+}
+
+type RecomputeResult struct {
+	SnapshotID          string                   `json:"snapshotId"`
+	GroupID             string                   `json:"groupId"`
+	GroupTitle          string                   `json:"groupTitle"`
+	GroupCategory       *string                  `json:"groupCategory"`
+	HasCentroid         bool                     `json:"hasCentroid"`
+	Articles            []RecomputeArticleResult `json:"articles"`
+	ThresholdSimulation ThresholdSimulation      `json:"thresholdSimulation"`
+}
+
+func RecomputeGroupInspect(ctx context.Context, pool *pgxpool.Pool, snapshotID, groupID string, threshold float64) (*RecomputeResult, error) {
+	detail, err := GetSnapshotGroupDetail(ctx, pool, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("get group: %w", err)
+	}
+
+	// Collect URLs
+	urls := make([]string, len(detail.Articles))
+	for i, a := range detail.Articles {
+		urls[i] = a.URL
+	}
+
+	// Get embeddings
+	embedMap, err := GetEmbeddingsByURLs(ctx, pool, urls)
+	if err != nil {
+		return nil, fmt.Errorf("get embeddings: %w", err)
+	}
+
+	// Compute centroid
+	var vecs [][]float32
+	for _, url := range urls {
+		if emb, ok := embedMap[url]; ok {
+			vecs = append(vecs, emb)
+		}
+	}
+	centroid := MeanVector(vecs)
+
+	result := &RecomputeResult{
+		SnapshotID:    detail.SnapshotID,
+		GroupID:       detail.GroupID,
+		GroupTitle:    detail.GroupTitle,
+		GroupCategory: detail.Category,
+		HasCentroid:   len(centroid) > 0,
+	}
+
+	sim := ThresholdSimulation{Threshold: threshold}
+
+	for _, a := range detail.Articles {
+		ar := RecomputeArticleResult{
+			URL:                 a.URL,
+			Title:               a.Title,
+			Source:              a.Source,
+			Category:            a.Category,
+			IsUnknownCategory:   a.Category == nil || *a.Category == "" || *a.Category == "other",
+			NearestNeighbors:    []RecomputeNeighbor{},
+			AlternativeClusters: []RecomputeAlternativeCluster{},
+		}
+
+		emb, hasEmb := embedMap[a.URL]
+		ar.HasEmbedding = hasEmb
+
+		if hasEmb && len(centroid) > 0 {
+			raw := float64(CosineSimilarity(emb, centroid))
+			ar.SimilarityBeforePenalty = &raw
+
+			// Category gate: match grouper.groupGreedy behavior (skip if category differs)
+			penalized := raw
+			if detail.Category != nil && a.Category != nil && *a.Category != "" && *detail.Category != "" && *a.Category != *detail.Category {
+				penalized = 0
+			}
+			ar.SimilarityAfterPenalty = &penalized
+			ar.SimilarityToCentroid = &penalized
+
+			joins := penalized > threshold
+			ar.WouldJoinAtThreshold = &joins
+			if joins {
+				sim.WouldStay++
+			} else {
+				sim.WouldLeave++
+			}
+
+			// Nearest neighbors
+			neighbors, _ := FindSimilarArticlesWithGroup(ctx, pool, emb, a.URL, 5)
+			for _, n := range neighbors {
+				nb := RecomputeNeighbor{
+					URL:        n.URL,
+					Title:      n.Title,
+					Source:     n.Source,
+					Similarity: float64(n.Similarity),
+				}
+				if n.GroupID != nil {
+					nb.GroupID = *n.GroupID
+				}
+				if n.GroupTitle != nil {
+					nb.GroupTitle = *n.GroupTitle
+				}
+				ar.NearestNeighbors = append(ar.NearestNeighbors, nb)
+			}
+
+			// Alternative clusters from neighbors (exclude current group)
+			seen := map[string]bool{}
+			for _, n := range neighbors {
+				if n.GroupID == nil || *n.GroupID == groupID || seen[*n.GroupID] {
+					continue
+				}
+				seen[*n.GroupID] = true
+				ac := RecomputeAlternativeCluster{
+					GroupID:    *n.GroupID,
+					Similarity: float64(n.Similarity),
+				}
+				if n.GroupTitle != nil {
+					ac.GroupTitle = *n.GroupTitle
+				}
+				ar.AlternativeClusters = append(ar.AlternativeClusters, ac)
+			}
+		} else {
+			sim.NoEmbedding++
+		}
+
+		result.Articles = append(result.Articles, ar)
+	}
+
+	result.ThresholdSimulation = sim
+	return result, nil
 }

--- a/src/app/inspect/page.tsx
+++ b/src/app/inspect/page.tsx
@@ -324,7 +324,7 @@ export default function InspectPage() {
                       const rcLoading = recomputeLoading.has(groupId);
                       const covered = g.coveredBy  ?? [];
                       const silent  = g.silentMedia ?? [];
-                      const issueCount = detail?.summary.issues.length ?? 0;
+                      const issueCount = detail?.summary?.issues?.length ?? 0;
                       return (
                         <div key={groupId} className={`rounded-lg border bg-white ${g.singleOutlet ? "opacity-60" : ""}`}>
                           <button
@@ -376,7 +376,7 @@ export default function InspectPage() {
                               )}
 
                               {/* Issues */}
-                              {detail && detail.summary.issues.length > 0 && (
+                              {detail && detail.summary?.issues && detail.summary.issues.length > 0 && (
                                 <div className="px-3 pt-2 space-y-1">
                                   {detail.summary.issues.map((issue, k) => (
                                     <div
@@ -416,7 +416,7 @@ export default function InspectPage() {
                               <ul className="px-3 pt-2 pb-2 divide-y divide-gray-50">
                                 {(detail?.articles ?? g.items ?? []).map((item, j) => {
                                   const cat = "category" in item ? item.category : null;
-                                  const rcArticle = recompute?.articles.find((a) => a.url === item.url);
+                                  const rcArticle = recompute?.articles?.find((a) => a.url === item.url);
                                   const artExpanded = expandedArticle.get(groupId) === j;
                                   return (
                                     <li key={j} className="py-1.5">


### PR DESCRIPTION
## Summary
- 設計書に記載の未実装ハンドラ4件を実装（BatchInspectRecompute, CompareAnalyze, YouTubeFeed, YouTubeAnalyze）
- `GetSnapshotGroupDetail` の返却型をフロントの `GroupInspectDetail` に合わせ、`summary` フィールドを追加
- inspect ページの optional chaining 不足によるランタイムエラーを修正
- SSE分析ストリーミングの共通ヘルパー抽出でコード重複を解消
- recompute のカテゴリゲート・閾値比較を `grouper.groupGreedy` と整合（`>=` → `>`, ペナルティ → ゲート）

## Test plan
- [ ] `go build ./...` がshared/server両方で成功することを確認
- [ ] inspect ページで `summary` 未定義時にクラッシュしないことを確認
- [ ] `/api/batch/inspect?groupId=xxx` が `GroupInspectDetail` 形式で返ることを確認
- [ ] `/api/batch/inspect/recompute` が閾値シミュレーション付きで返ることを確認
- [ ] `/api/youtube/feed?channels=tbsnews,annnews` が動画一覧を返すことを確認
- [ ] `/api/compare/analyze` がSSEで記事分析結果をストリーミングすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)