### PR TITLE
fix: e5-large-instruct移行とrecompute診断カテゴリゲート修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 ## pgvector
 
-- `Unsupported("vector(768)")` カラムは Prisma CRUD では操作不可 → 生SQL必須
+- `Unsupported("vector(1024)")` カラムは Prisma CRUD では操作不可 → 生SQL必須
 - `embedding IS NOT NULL` フィルタを忘れずに
 - INSERT: `$1::vector`、検索: `embedding <=> $1::vector`（コサイン距離）
 

--- a/batch/internal/config/config.go
+++ b/batch/internal/config/config.go
@@ -42,7 +42,7 @@ func Load() Config {
 		BERTopicConfig: BERTopicConfig{
 			PythonPath:        config.GetEnv("BERTOPIC_PYTHON_PATH", "python3"),
 			ScriptPath:        config.GetEnv("BERTOPIC_SCRIPT_PATH", "../scripts/bertopic_cluster.py"),
-			MinClusterSize:    int(config.GetFloat("BERTOPIC_MIN_CLUSTER_SIZE", 4)),
+			MinClusterSize:    int(config.GetFloat("BERTOPIC_MIN_CLUSTER_SIZE", 2)),
 			UMAPComponents:    int(config.GetFloat("BERTOPIC_UMAP_COMPONENTS", 15)),
 			TimeoutSec:        int(config.GetFloat("BERTOPIC_TIMEOUT_SEC", 120)),
 			FallbackThreshold: groupThreshold,

--- a/batch/internal/pipeline/steps/classify.go
+++ b/batch/internal/pipeline/steps/classify.go
@@ -39,8 +39,8 @@ func loadRefEmbeddings(ctx context.Context, embedClient *llm.EmbedClient) ([]sub
 		for i, s := range subs {
 			texts[i] = s.Text
 		}
-		// サブカテゴリ説明はドキュメント側（"文章: " プレフィックス）
-		vecs, err := embedClient.EmbedBatchWithPrefix(ctx, texts, "文章: ")
+		// サブカテゴリ説明を embedding 化（e5-instruct: query prefix）
+		vecs, err := embedClient.EmbedBatchWithPrefix(ctx, texts, "query: ")
 		if err != nil {
 			refErr = fmt.Errorf("reference embedding failed: %w", err)
 			return
@@ -279,8 +279,8 @@ func Classify(ctx context.Context, pool *db.Pool, embedClient *llm.EmbedClient, 
 			}
 			texts[i] = text
 		}
-		// 記事はクエリ側（"クエリ: " プレフィックス）
-		vecs, embedErr := embedClient.EmbedBatchWithPrefix(ctx, texts, "クエリ: ")
+		// 記事を embedding 化（e5-instruct: query prefix）
+		vecs, embedErr := embedClient.EmbedBatchWithPrefix(ctx, texts, "query: ")
 		if embedErr != nil {
 			slog.Warn("classify: article embedding failed, falling back to keywords", "err", embedErr)
 			vecs = nil

--- a/docker-compose.local-ollama.yml
+++ b/docker-compose.local-ollama.yml
@@ -30,7 +30,7 @@ services:
       - EMBED_BASE_URL=${LLM_BASE_URL:-http://host-gateway:8080}
       - LLM_MODEL=${LLM_MODEL:-ggml-org/gemma3:4b}
       - CLASSIFY_MODEL=${CLASSIFY_MODEL:-ggml-org/gemma3:4b}
-      - EMBED_MODEL=${EMBED_MODEL:-ruri-v3-310m}
+      - EMBED_MODEL=${EMBED_MODEL:-multilingual-e5-large-instruct-q8_0}
     extra_hosts:
       - "host-gateway:host-gateway"
     depends_on:
@@ -51,7 +51,7 @@ services:
       - EMBED_BASE_URL=${LLM_BASE_URL:-http://host-gateway:8080}
       - LLM_MODEL=${LLM_MODEL:-ggml-org/gemma3:4b}
       - CLASSIFY_MODEL=${CLASSIFY_MODEL:-ggml-org/gemma3:4b}
-      - EMBED_MODEL=${EMBED_MODEL:-ruri-v3-310m}
+      - EMBED_MODEL=${EMBED_MODEL:-multilingual-e5-large-instruct-q8_0}
       - API_PORT=8091
       - BATCH_SERVER_URL=http://batch:8090
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - EMBED_BASE_URL=${LLM_BASE_URL:-http://ollama:11434}
       - LLM_MODEL=${LLM_MODEL:-ggml-org/gemma3:4b}
       - CLASSIFY_MODEL=${CLASSIFY_MODEL:-ggml-org/gemma3:4b}
-      - EMBED_MODEL=${EMBED_MODEL:-ruri-v3-310m}
+      - EMBED_MODEL=${EMBED_MODEL:-multilingual-e5-large-instruct-q8_0}
     depends_on:
       db-migrate:
         condition: service_completed_successfully
@@ -42,7 +42,7 @@ services:
       - EMBED_BASE_URL=${LLM_BASE_URL:-http://ollama:11434}
       - LLM_MODEL=${LLM_MODEL:-ggml-org/gemma3:4b}
       - CLASSIFY_MODEL=${CLASSIFY_MODEL:-ggml-org/gemma3:4b}
-      - EMBED_MODEL=${EMBED_MODEL:-ruri-v3-310m}
+      - EMBED_MODEL=${EMBED_MODEL:-multilingual-e5-large-instruct-q8_0}
       - API_PORT=8091
       - BATCH_SERVER_URL=http://batch:8090
     depends_on:
@@ -97,9 +97,9 @@ services:
     environment:
       - OLLAMA_HOST=http://ollama:11434
       - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.2}
-      - EMBED_MODEL=${EMBED_MODEL:-ruri-v3-310m}
+      - EMBED_MODEL=${EMBED_MODEL:-multilingual-e5-large-instruct-q8_0}
     entrypoint: >
-      sh -c "ollama pull $${OLLAMA_MODEL:-llama3.2} && ollama pull $${EMBED_MODEL:-ruri-v3-310m}"
+      sh -c "ollama pull $${OLLAMA_MODEL:-llama3.2} && ollama pull $${EMBED_MODEL:-multilingual-e5-large-instruct-q8_0}"
     restart: "no"
 
   db:

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -27,7 +27,7 @@ func LoadShared() SharedConfig {
 		LLMModel:               GetEnv("LLM_MODEL", "gemma-4-E2B-it-Q8_0"),
 		ClassifyModel:          GetEnv("CLASSIFY_MODEL", "gemma-4-E2B-it-Q8_0"),
 		RefineModel:            GetEnv("REFINE_MODEL", "gemma-4-E2B-it-Q8_0"),
-		EmbedModel:             GetEnv("EMBED_MODEL", "Targoyle/ruri-v3-310m-GGUF:Q8_0"),
+		EmbedModel:             GetEnv("EMBED_MODEL", "multilingual-e5-large-instruct-q8_0"),
 		GroupClusterThreshold:  GetFloat("GROUP_CLUSTER_THRESHOLD", 0.91),
 		EmbedClassifyThreshold: GetFloat("EMBED_CLASSIFY_THRESHOLD", 0.8),
 	}

--- a/shared/db/articles.go
+++ b/shared/db/articles.go
@@ -138,7 +138,7 @@ func GetRecentEmbeddedArticles(ctx context.Context, pool *pgxpool.Pool) ([]Artic
 	rows, err := pool.Query(ctx, `
 		SELECT url, title, source, summary, published_at, COALESCE(category,''), COALESCE(subcategory,''), embedding::text
 		FROM rss_articles
-		WHERE embedded_at IS NOT NULL
+		WHERE embedding IS NOT NULL
 		  AND published_at >= NOW() - INTERVAL '3 days'
 		ORDER BY published_at DESC NULLS LAST`,
 	)

--- a/shared/db/snapshots.go
+++ b/shared/db/snapshots.go
@@ -447,16 +447,10 @@ func RecomputeGroupInspect(ctx context.Context, pool *pgxpool.Pool, snapshotID, 
 		if hasEmb && len(centroid) > 0 {
 			raw := float64(CosineSimilarity(emb, centroid))
 			ar.SimilarityBeforePenalty = &raw
+			ar.SimilarityAfterPenalty = &raw
+			ar.SimilarityToCentroid = &raw
 
-			// Category gate: match grouper.groupGreedy behavior (skip if category differs)
-			penalized := raw
-			if detail.Category != nil && a.Category != nil && *a.Category != "" && *detail.Category != "" && *a.Category != *detail.Category {
-				penalized = 0
-			}
-			ar.SimilarityAfterPenalty = &penalized
-			ar.SimilarityToCentroid = &penalized
-
-			joins := penalized > threshold
+			joins := raw > threshold
 			ar.WouldJoinAtThreshold = &joins
 			if joins {
 				sim.WouldStay++

--- a/shared/llm/chat.go
+++ b/shared/llm/chat.go
@@ -63,7 +63,7 @@ func (c *ChatClient) CompleteJSON(ctx context.Context, system, user string) (str
 		},
 		"stream":          false,
 		"temperature":     0.1,
-		"max_tokens":      2048,
+		"max_tokens":      8192,
 		"response_format": map[string]string{"type": "json_object"},
 	})
 	if err != nil {

--- a/shared/llm/embed.go
+++ b/shared/llm/embed.go
@@ -28,7 +28,7 @@ const embedChunkSize = 32
 
 // Embed vectorizes a single text string using query prefix.
 func (c *EmbedClient) Embed(ctx context.Context, text string) ([]float32, error) {
-	vecs, err := c.EmbedBatchWithPrefix(ctx, []string{text}, "クエリ: ")
+	vecs, err := c.EmbedBatchWithPrefix(ctx, []string{text}, "query: ")
 	if err != nil || len(vecs) == 0 {
 		return nil, err
 	}
@@ -36,14 +36,14 @@ func (c *EmbedClient) Embed(ctx context.Context, text string) ([]float32, error)
 }
 
 // EmbedBatch vectorizes texts in chunks of embedChunkSize per HTTP request.
-// Uses the document prefix ("文章: ") for article/document embeddings.
+// Uses the clustering instruction prefix for article/document embeddings.
 // Returns nil slice elements for failed items.
 func (c *EmbedClient) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
-	return c.EmbedBatchWithPrefix(ctx, texts, "文章: ")
+	return c.EmbedBatchWithPrefix(ctx, texts, "Instruct: ニュース記事を具体的な出来事・事件単位でクラスタリングする\nQuery: ")
 }
 
 // EmbedBatchWithPrefix vectorizes texts using the specified prefix.
-// Use "文章: " for documents and "クエリ: " for queries (ruri-v3 asymmetric model).
+// e5-instruct format: "query: " for queries, "Instruct: ...\nQuery: " for task-specific.
 func (c *EmbedClient) EmbedBatchWithPrefix(ctx context.Context, texts []string, prefix string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil


### PR DESCRIPTION
## Summary
- embeddingモデルをruri-v3からmultilingual-e5-large-instruct-q8_0に移行（vector次元768→1024、プレフィックス形式を統一）
- inspect画面の再計算診断で別カテゴリの記事が`0.000`と表示されるバグを修正（実際のgrouperにはカテゴリゲートが存在しないため、誤ったペナルティロジックを削除）
- その他: `embedded_at`→`embedding IS NOT NULL`修正、`max_tokens`拡大、BERTopic最小クラスタサイズ調整

## Test plan
- [x] `shared/db` テスト通過を確認
- [x] inspect画面でrecompute診断を実行し、別カテゴリの記事が実際の類似度スコアで表示されることを確認
- [x] embeddingの生成が新モデルで正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)