### PR TITLE
feat: クラスタリング分析スキルとチューニングガイドを追加

### DIFF
--- a/.claude/skills/analyze-clusters/SKILL.md
+++ b/.claude/skills/analyze-clusters/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: analyze-clusters
+description: グルーピングログ(batch/logs/group_*.json)を分析し、クラスタリング品質を評価する。問題パターン(過合流・過分離・ノイズ過多)を特定し改善提案を行う。
+model: haiku
+disable-model-invocation: true
+allowed-tools: Bash Read Glob Grep
+---
+
+# クラスタリング分析スキル
+
+グルーピングログを分析してクラスタリング品質を評価する。
+
+## 引数
+
+- 引数なし: 最新のログを分析
+- ファイルパス指定: 指定ログを分析
+- 2つのファイルパス: 2つのログをA/B比較
+
+## 実行手順
+
+### Step 1: ログ特定
+
+引数がなければ `batch/logs/group_*.json` の最新ファイルを使う。
+
+### Step 2: 基本統計の算出
+
+以下のBashコマンドで統計サマリーを出す:
+
+```bash
+python3 -c "
+import json, sys
+with open('TARGET_FILE') as f:
+    d = json.load(f)
+total = sum(e['size'] for e in d)
+multi = [e for e in d if e['size'] >= 2]
+noise = [e for e in d if e['size'] == 1]
+print(f'articles: {total}')
+print(f'clusters: {len(d)} (multi: {len(multi)}, single: {len(noise)})')
+print(f'noise rate: {len(noise)/len(d)*100:.1f}%')
+if multi:
+    sims = [e['avg_similarity'] for e in multi]
+    sims.sort()
+    n = len(sims)
+    print(f'avg_similarity p10={sims[int(0.1*(n-1))]:.4f} p50={sims[n//2]:.4f} p90={sims[int(0.9*(n-1))]:.4f}')
+sizes = {}
+for e in d:
+    sizes[e['size']] = sizes.get(e['size'], 0) + 1
+print('size distribution:', dict(sorted(sizes.items())))
+# 大きすぎるクラスタ
+big = [e for e in d if e['size'] >= 15]
+if big:
+    print(f'\n--- 大クラスタ (size>=15) ---')
+    for e in big:
+        print(f'Group {e[\"index\"]}: size={e[\"size\"]}, sim={e[\"avg_similarity\"]:.4f}')
+        for a in e['articles'][:5]:
+            print(f'  - {a[\"title\"][:50]}')
+        if e['size'] > 5:
+            print(f'  ... (残り{e[\"size\"]-5}件)')
+"
+```
+
+### Step 3: 健全性指標の評価
+
+以下の基準でログを評価する:
+
+| 指標 | 目安 | 判定 |
+|:--|:--|:--|
+| noise rate | < 25% | 超えると過分離の疑い |
+| 最大クラスタサイズ | < 30 | 超えると過合流の疑い |
+| size 2-3 のクラスタ数 | 0でない | 0なら min_cluster_size が高すぎ |
+| avg_similarity p10 | > 0.90 | 下回ると内部不一致の疑い |
+
+### Step 4: 問題パターンの特定
+
+以下の3パターンを自動チェックする:
+
+#### A. 過合流チェック
+size >= 10 のクラスタについて、全記事タイトルを出力し、内容の一貫性を目視で評価。異なるトピックの混在がないか確認する。特に:
+- 「キーワードが同じだが別の事件」(例: "警察官"で異なる事件がまとまる)
+- 「カテゴリレベルで雑にまとまっている」(例: スポーツ全般が1グループ)
+
+#### B. 過分離チェック
+同一トピックの記事が別グループに分かれていないか。タイトルの類似パターンをgrepで探す:
+```bash
+python3 -c "
+import json
+with open('TARGET_FILE') as f:
+    d = json.load(f)
+# タイトルの先頭20文字が類似する記事を異なるグループから探す
+from collections import defaultdict
+prefix_map = defaultdict(list)
+for g in d:
+    for a in g['articles']:
+        prefix = a['title'][:20]
+        prefix_map[prefix].append(g['index'])
+for prefix, groups in prefix_map.items():
+    unique = set(groups)
+    if len(unique) > 1:
+        print(f'分離疑い: \"{prefix}...\" → Group {sorted(unique)}')
+"
+```
+
+#### C. consensus不整合チェック
+consensusに記載された内容が、そのグループの記事と合致しているか確認する:
+```bash
+python3 -c "
+import json
+with open('TARGET_FILE') as f:
+    d = json.load(f)
+for g in d:
+    if g['size'] >= 2 and 'consensus' in g and g['consensus']:
+        titles_text = ' '.join(a['title'] for a in g['articles'])
+        for c in g['consensus'][:3]:
+            # consensus内のキーワードが記事タイトルに1つも含まれないケースを検出
+            fact_words = [w for w in c['fact'].split() if len(w) >= 3]
+            match_count = sum(1 for w in fact_words if w in titles_text)
+            if match_count == 0 and len(fact_words) >= 3:
+                print(f'Group {g[\"index\"]}: consensus \"{c[\"fact\"][:60]}\" がタイトルと不一致')
+"
+```
+
+### Step 5: レポート出力
+
+以下の形式で日本語レポートを出力する:
+
+```
+## クラスタリング分析レポート
+対象: {ファイル名}
+
+### 基本統計
+(Step 2の結果をテーブルで)
+
+### 健全性判定
+(Step 3の各指標にOK/NG判定)
+
+### 検出された問題
+(Step 4の結果を問題パターン別に列挙)
+
+### 改善提案
+(検出された問題パターンに基づき、docs/guide/clustering-tuning-playbook.md のパラメータ調整を提案)
+```
+
+### Step 6: A/B比較 (2つのログ指定時のみ)
+
+2つのログが指定された場合、以下を追加で出力:
+
+```bash
+python3 -c "
+import json, sys
+with open('BEFORE_FILE') as f:
+    before = json.load(f)
+with open('AFTER_FILE') as f:
+    after = json.load(f)
+def stats(d):
+    total = sum(e['size'] for e in d)
+    multi = [e for e in d if e['size'] >= 2]
+    noise = [e for e in d if e['size'] == 1]
+    sims = [e['avg_similarity'] for e in multi] if multi else [0]
+    return {
+        'articles': total, 'clusters': len(d),
+        'multi': len(multi), 'noise': len(noise),
+        'noise_rate': len(noise)/len(d)*100,
+        'sim_mean': sum(sims)/len(sims),
+        'max_size': max(e['size'] for e in d),
+    }
+b, a = stats(before), stats(after)
+print(f'| 指標 | Before | After | 変化 |')
+print(f'|---|---|---|---|')
+for k in ['clusters','multi','noise','noise_rate','sim_mean','max_size']:
+    fmt = '.1f' if k in ('noise_rate','sim_mean') else 'd'
+    print(f'| {k} | {b[k]:{fmt}} | {a[k]:{fmt}} | {a[k]-b[k]:+{fmt}} |')
+"
+```

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,499 @@
+# 全体コードレビュー
+
+日付: 2026-04-13
+
+---
+
+## Critical（致命的バグ）
+
+### C-1: SSRF: `RSS` ハンドラでユーザー指定URLを無検証で fetch
+
+**ファイル:** `server/internal/handler/rss.go:10-22`
+
+```go
+feedUrl := r.URL.Query().Get("feedUrl")
+parser := gofeed.NewParser()
+feed, err := parser.ParseURL(feedUrl)  // ← ユーザー入力をそのまま使用
+```
+
+**問題:** `feedUrl` クエリパラメータを検証なく `gofeed.ParseURL` に渡している。内部ネットワーク（`http://169.254.169.254` など AWS metadata service）への SSRF が可能。
+
+**対策:** 
+- ホワイトリスト形式で許可する URL プレフィックスを制限
+- または `url.Parse` で scheme が `http/https` のみに限定
+
+---
+
+### C-2: `Config` エンドポイントが設定全体を公開
+
+**ファイル:** `server/internal/handler/config.go:5-7`
+
+```go
+func (d *Deps) Config_(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, d.Config)  // ← SharedConfig 全体を返す
+}
+```
+
+**問題:** `SharedConfig` に含まれる `DatabaseURL`、`LLMBaseURL`、API キー、パスワードなどの内部情報がすべて JSON で返される。誰でもアクセス可能。
+
+**対策:** フロントエンドに必要な項目のみを選別して返す構造体を作成
+
+```go
+type PublicConfig struct {
+	// フロントに必要な項目のみ
+}
+```
+
+---
+
+### C-3: `classify.go` の `refOnce` がプロセス寿命の間ずっとキャッシュ
+
+**ファイル:** `batch/internal/pipeline/steps/classify.go:29-31`
+
+```go
+var (
+	refOnce sync.Once
+	refVecs []subRef
+	refErr  error
+)
+```
+
+**問題:** `sync.Once` で参照 embedding を一度だけロードするが、taxonomy が変更されてもプロセス再起動まで古いデータが使われ続ける。`serve` モードでは長時間プロセスなので、分類精度が劣化しうる。
+
+**対策:** TTL 付きキャッシュ（例: 1時間で無効化）に変更するか、定期的にリロード
+
+---
+
+### C-4: setState 内の入れ子 setState
+
+**ファイル:** `src/app/page.tsx:117`
+
+```tsx
+setArticles((prev) => {
+  articleIdx = 0;
+  setSelectedIndex(0);  // ← setState コールバック内で別の setState を呼び出し
+  return [analyzed, ...prev];
+});
+```
+
+**問題:** React の state setter のコールバック内で別の `setState` を呼ぶのは非推奨。strict mode での二重実行時に予期しない挙動が発生する。
+
+**対策:** コールバック外で依存関係を整理するか、1つの state にまとめる
+
+```tsx
+setArticlesAndIndex((prev) => ({
+  articles: [analyzed, ...prev.articles],
+  selectedIndex: 0
+}));
+```
+
+---
+
+## Warning（警告: 動作上の問題・潜在バグ）
+
+### W-1: Graceful shutdown の timeout なし
+
+**ファイル:** `server/cmd/newsprism-server/main.go:64`, `batch/cmd/newsprism-batch/main.go:108`
+
+```go
+srv.Shutdown(ctx)  // ctx に timeout がない
+```
+
+**問題:** `srv.Shutdown` に渡す `ctx` が `context.Background()` で timeout がない。SSE 接続等が残っている場合、永久にブロックする。
+
+**対策:** timeout 付き context を使用
+
+```go
+shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+srv.Shutdown(shutdownCtx)
+```
+
+---
+
+### W-2: `CompareAnalyze` が順次スクレイピング
+
+**ファイル:** `server/internal/handler/compare.go:63-64`
+
+```go
+for i, item := range req.Items {
+	content, err := scraper.FetchArticleFromUrl(item.URL)  // 順次実行
+	if err != nil || len([]rune(content)) < 10 {
+		content = item.Title
+	}
+```
+
+**問題:** 各記事の URL を順次 fetch しており、記事数 × 10秒（scraper タイムアウト）のレイテンシが発生しうる。
+
+**対策:** goroutine でバッチ並行化（例: worker pool パターン）
+
+---
+
+### W-3: `Compare` の `rss.FetchAllFeeds` エラー無視
+
+**ファイル:** `server/internal/handler/compare.go:27`
+
+```go
+allItems, _ := rss.FetchAllFeeds(r.Context(), feeds)  // エラーを捨てている
+matched := rss.FilterByKeyword(allItems, keyword)
+```
+
+**問題:** 全フィード取得失敗時でも空の結果を返してしまう。ユーザーに失敗が伝わらない。
+
+**対策:** エラーをチェックしてログ + エラーレスポンス返送
+
+---
+
+### W-4: `name.go` の並行 LLM 呼び出しに制限なし
+
+**ファイル:** `batch/internal/pipeline/steps/name.go:61-76`
+
+```go
+for start := 0; start < len(multi); start += nameChunkSize {
+	// ...
+	go func(multiSlice []indexedCluster, chunk []Cluster, start int) {
+		// LLM 呼び出し（同時実行数制限なし）
+	}(multiSlice, chunk, start)
+}
+```
+
+**問題:** チャンク数分の goroutine を同時に起動するが、制限がない。クラスタ数が多い場合に LLM サーバーに過負荷。
+
+**対策:** semaphore で同時実行数を制限（例: 3-5 並行）
+
+---
+
+### W-5: `InspectPage` の二重ローディングスピナー表示
+
+**ファイル:** `src/app/inspect/page.tsx:365-376`
+
+```tsx
+{open && !detail && inspectCache.has(groupId) === false && (
+  <div>...</div>  // スピナー1
+)}
+{open && !inspectCache.has(groupId) && (
+  <div>...</div>  // スピナー2（同時表示される）
+)}
+```
+
+**問題:** 2つのローディング条件が実質同じため、スピナーが重複表示される。
+
+**対策:** 条件を明確に分離
+
+```tsx
+{open && !inspectCache.has(groupId) && (
+  <div><!-- fetch 中 --></div>
+)}
+{open && inspectCache.has(groupId) && inspectCache.get(groupId) === null && (
+  <div><!-- エラー状態 --></div>
+)}
+```
+
+---
+
+### W-6: `PositioningPlot` のフック配列違反
+
+**ファイル:** `src/components/PositioningPlot.tsx:276`
+
+```tsx
+const svgRefs = [useRef<SVGSVGElement>(null), useRef<SVGSVGElement>(null)];
+```
+
+**問題:** React Hooks ルール違反。配列リテラル内での useRef 呼び出しは禁止。`PLOTS` 長が変わると壊れる。
+
+**対策:** 個別の変数に分割するか、`useCallback` で管理
+
+```tsx
+const svgRef0 = useRef<SVGSVGElement>(null);
+const svgRef1 = useRef<SVGSVGElement>(null);
+const svgRefs = [svgRef0, svgRef1];
+```
+
+---
+
+### W-7: `FeedSettingsDrawer` の URL バリデーション不足
+
+**ファイル:** `src/components/FeedSettingsDrawer.tsx:100`
+
+```ts
+try { new URL(url); } catch { alert("有効な URL を入力してください"); return; }
+```
+
+**問題:** `new URL("javascript:alert(1)")` は例外を投げない。`javascript:` スキームの XSS が可能。
+
+**対策:** スキームの明示チェック
+
+```ts
+try {
+  const parsed = new URL(url);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('Only HTTP/HTTPS allowed');
+  }
+} catch { ... }
+```
+
+---
+
+### W-8: `formatRelative` の3箇所重複
+
+**ファイル:** 
+- `src/components/RankingHeroCard.tsx:156-164`
+- `src/components/RankingMediumCard.tsx:134-142`
+- `src/lib/format-time.ts`
+
+**問題:** 同一ロジックが3箇所に存在。仕様変更時に diverge するリスク。
+
+**対策:** 共通の関数をインポートして使用
+
+---
+
+### W-9: `parse-sse.ts` が未使用
+
+**ファイル:** `src/lib/parse-sse.ts`
+
+**問題:** 共通化された SSE パーサーがあるのに、実際の SSE 処理箇所（`page.tsx`, `compare/page.tsx`, `youtube/page.tsx`, `CoverageMatrix.tsx`）はすべて独自にインライン実装。
+
+**対策:** 各所で `parseSSEBuffer` を使用するよう統一
+
+---
+
+### W-10: `MediaComparisonView` の空配列時に `-Infinity` 表示
+
+**ファイル:** `src/components/MediaComparisonView.tsx:231-233`
+
+```tsx
+const gaps = (["economic", "social", "diplomatic"] as const).map((key) => {
+  const vals = results.map((r) => r.analysis.scores[key]);
+  return Math.max(...vals) - Math.min(...vals);  // results 空時: -Infinity
+});
+```
+
+**問題:** `results` が空の場合、`Math.max(...[])` が `-Infinity` を返し、UI に表示される。
+
+**対策:** 事前チェック
+
+```tsx
+if (results.length === 0) return null;
+```
+
+---
+
+### W-11: `compare/page.tsx` の「別のグループを比較」で空配列リセット
+
+**ファイル:** `src/app/compare/page.tsx:299`
+
+```tsx
+onClick={() => setStep({ type: "grouped", groups: [] })}
+```
+
+**問題:** `groups: []` で元の検索結果を失い、「0件のニュースグループが見つかりました」と表示される。
+
+**対策:** 直前の groups を保持して戻る
+
+```tsx
+const [lastGroups, setLastGroups] = useState<NewsGroup[]>([]);
+// ...
+onClick={() => setStep({ type: "grouped", groups: lastGroups })}
+```
+
+---
+
+## Minor（軽微な問題）
+
+### M-1: `float64` の等値比較
+
+**ファイル:** `batch/internal/pipeline/steps/store.go:73`
+
+```go
+if a.finalScore != b.finalScore {
+	return a.finalScore > b.finalScore
+}
+```
+
+**問題:** 浮動小数点の `!=` 比較は精度誤差で予期しない結果になりうる。
+
+**対策:** 差分の閾値比較
+
+```go
+const epsilon = 1e-9
+if math.Abs(a.finalScore - b.finalScore) > epsilon {
+	return a.finalScore > b.finalScore
+}
+```
+
+---
+
+### M-2: `classify.go` の `min` 関数が Go 1.21+ builtin と衝突
+
+**ファイル:** `batch/internal/pipeline/steps/classify.go:366-371`
+
+```go
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+```
+
+**問題:** Go 1.21 で `min`/`max` が builtin 追加。shadowing が発生し紛らわしい。
+
+**対策:** 関数名を `minInt` に変更するか、builtin を使用
+
+```go
+result := slices.Min(lengths)  // Go 1.21+
+```
+
+---
+
+### M-3: `RssFeedPanel` の `border-3` が Tailwind v4 で無効
+
+**ファイル:** `src/components/RssFeedPanel.tsx:350`
+
+```tsx
+<div className="w-8 h-8 border-3 border-gray-200 border-t-blue-500 rounded-full animate-spin mb-4" />
+```
+
+**問題:** Tailwind v4 では `border-3` は存在しない。無視される。
+
+**対策:** 任意値記法を使用
+
+```tsx
+className="w-8 h-8 border-[3px] border-gray-200 border-t-blue-500 rounded-full animate-spin mb-4"
+```
+
+---
+
+### M-4: ダークモードが `bg-gray-50` で上書き
+
+**ファイル:** `src/app/layout.tsx:31` + `src/app/globals.css:15-20`
+
+```tsx
+<body className="bg-gray-50">
+```
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root { --background: #0a0a0a; }
+}
+```
+
+**問題:** CSS 変数で定義したダークモード背景が `bg-gray-50` で上書きされる。
+
+**対策:** body に背景色クラスを指定しない、または `bg-[var(--background)]` を使用
+
+---
+
+### M-5: `topic-classifier.ts` のコメント矛盾
+
+**ファイル:** `src/lib/topic-classifier.ts:118-119`
+
+```ts
+// 優先度順（先にマッチしたものが採用される）
+// disaster は自然災害に限定するため politics/economy より後ろ
+export const TOPIC_ORDER: string[] = [
+  "disaster",  // ← でも先頭
+```
+
+**問題:** 日本語コメントは後ろと説明、実装は先頭。英語コメントで優先度を上げたとあるが矛盾。
+
+**対策:** コメント統一
+
+```ts
+// 優先度順（先にマッチしたものが採用される）
+// disaster は迅速なアラート必要なため最優先
+```
+
+---
+
+### M-6: `NewsGroupCard` の日付ソートが辞書順
+
+**ファイル:** `src/components/NewsGroupCard.tsx:13-16`
+
+```ts
+const latestDate = group.items
+  .map((i) => i.publishedAt)
+  .filter(Boolean)
+  .sort()
+  .at(-1);
+```
+
+**問題:** `.sort()` がデフォルトの文字列比較。
+ISO 8601 なら正しいが、RFC 2822 形式が混入すると壊れる。
+
+**対策:** 数値ソート
+
+```ts
+.sort((a, b) => new Date(a).getTime() - new Date(b).getTime())
+```
+
+---
+
+### M-7: `stringToHue` のハッシュ関数でオーバーフロー
+
+**ファイル:** `src/lib/source-colors.ts:58-63`
+
+```ts
+function stringToHue(str: string): number {
+  let hash = 5381;
+  for (const c of str) {
+    hash = (hash * 33) ^ c.charCodeAt(0);  // 浮動小数点精度損失
+  }
+  return Math.abs(hash) % 360;
+}
+```
+
+**問題:** `hash * 33` で `Number.MAX_SAFE_INTEGER` を超え、ビット演算の精度が失われる。
+
+**対策:** 32ビット符号なし整数にクランプ
+
+```ts
+hash = ((hash * 33) ^ c.charCodeAt(0)) >>> 0;  // 32bit unsigned
+```
+
+---
+
+### M-8: `ArticleHistory` / `CompareHistory` のエラーハンドリング欠如
+
+**ファイル:** 
+- `src/components/ArticleHistory.tsx:18-27`
+- `src/components/CompareHistory.tsx:24-33`
+
+**問題:** `fetch` 失敗時にユーザーへのエラー表示がない。ローディング解除のみで、ユーザーは失敗に気づけない。
+
+**対策:** エラー状態を管理・表示
+
+```tsx
+const [error, setError] = useState<string | null>(null);
+const [loading, setLoading] = useState(false);
+
+const load = async () => {
+  try {
+    // ...
+  } catch (e) {
+    setError(e instanceof Error ? e.message : "読み込みに失敗しました");
+  }
+};
+```
+
+---
+
+## 対応優先度
+
+1. **即座に対応すべき（Security）**
+   - C-1: SSRF
+   - C-2: Config 漏洩
+
+2. **早期対応推奨（Correctness）**
+   - C-3: classify キャッシュ
+   - C-4: setState 入れ子
+   - W-1: Graceful shutdown timeout
+   - W-6: Hooks ルール違反
+
+3. **中期対応（Code Quality）**
+   - W-2, W-3, W-4: スクレイピング並行化・エラーハンドリング
+   - W-8, W-9: コード重複排除
+   - M-3, M-4: Tailwind v4 対応
+
+4. **Low Priority（Style / Minor）**
+   - M-1, M-2, M-5, M-6, M-7, M-8

--- a/docs/guide/clustering-tuning-playbook.md
+++ b/docs/guide/clustering-tuning-playbook.md
@@ -1,0 +1,241 @@
+# クラスタリング精度改善プレイブック
+
+## 前提: 現在のパイプライン構成
+
+```
+記事収集 → Embedding(ruri-v3) → 分類 → グルーピング → LLM精査(refine) → 命名 → コンセンサス → 保存
+```
+
+グルーピングは2方式が切替可能:
+- **Greedy Cosine** (`group.go`): 768次元のまま貪欲法。閾値 `GROUP_CLUSTER_THRESHOLD`
+- **BERTopic** (`bertopic_cluster.py`): UMAP次元削減 → HDBSCAN密度クラスタリング。`USE_BERTOPIC=true` で有効化
+
+---
+
+## 1. 改善ループの概要
+
+```
+① ログ取得 → ② 問題分類 → ③ 仮説立て → ④ パラメータ変更 → ⑤ 再実行 → ⑥ 比較評価
+     ↑                                                                      |
+     └──────────────────────────────────────────────────────────────────────┘
+```
+
+1回のループで**1つのパラメータだけ**変更する。複数同時に変えると因果が追えない。
+
+---
+
+## 2. ログ取得と現状把握
+
+### 2.1 グループログの確認
+
+バッチ実行ごとに `batch/logs/group_YYYYMMDD_HHMMSS.json` が出力される。
+
+```bash
+# 最新ログの統計サマリー
+cat batch/logs/group_$(ls -t batch/logs/ | head -1) | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+total = sum(e['size'] for e in d)
+multi = [e for e in d if e['size'] >= 2]
+noise = [e for e in d if e['size'] == 1]
+print(f'articles: {total}')
+print(f'clusters: {len(d)} (multi: {len(multi)}, single: {len(noise)})')
+print(f'noise rate: {len(noise)/len(d)*100:.1f}%')
+if multi:
+    sims = [e['avg_similarity'] for e in multi]
+    sims.sort()
+    n = len(sims)
+    print(f'avg_similarity p10={sims[int(0.1*(n-1))]:.4f} p50={sims[n//2]:.4f} p90={sims[int(0.9*(n-1))]:.4f}')
+# サイズ分布
+sizes = {}
+for e in d:
+    sizes[e['size']] = sizes.get(e['size'], 0) + 1
+print('size distribution:', dict(sorted(sizes.items())))
+"
+```
+
+### 2.2 注目すべき指標
+
+| 指標 | 目安 | 意味 |
+|:--|:--|:--|
+| noise rate (単独記事率) | < 25% | 高すぎると有効なクラスタを見逃している |
+| 最大クラスタサイズ | < 30 | 大きすぎると異なるトピックが混在している可能性 |
+| size 2-3 のクラスタ数 | 0でない | 0なら min_cluster_size が高すぎる (BERTopic) |
+| avg_similarity p10 | > 0.90 | 低いクラスタは内部不一致の疑い |
+
+### 2.3 /inspect ページでの目視確認
+
+`/inspect` → snapshot タブで個別グループを展開し、以下を確認:
+- 明らかに異なるトピックの記事が混在していないか（過合流）
+- 同じトピックの記事が別グループに分かれていないか（過分離）
+- recompute で `alternativeClusters` の類似度が高い記事がないか
+
+---
+
+## 3. 問題パターンと対応
+
+### パターンA: 過合流（異なるトピックが1つのクラスタに）
+
+**症状**: 大きなクラスタに無関係な記事が混入
+
+**確認方法**:
+```bash
+# サイズ20以上のクラスタのタイトル一覧
+cat batch/logs/group_*.json | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for e in d:
+    if e['size'] >= 20:
+        print(f'--- cluster {e[\"index\"]} (size={e[\"size\"]}, sim={e[\"avg_similarity\"]:.4f}) ---')
+        for a in e['articles']:
+            print(f'  [{a[\"source\"]}] {a[\"title\"]}')
+        print()
+" | less
+```
+
+**対策（優先順）**:
+1. Greedy: `GROUP_CLUSTER_THRESHOLD` を上げる（0.91 → 0.92 など）
+2. BERTopic: `BERTOPIC_MIN_CLUSTER_SIZE` を上げる / `BERTOPIC_UMAP_COMPONENTS` を調整
+3. Refine: `REFINE_INTRA_THRESHOLD` を上げてsplit判定を厳しくする
+
+### パターンB: 過分離（同じトピックが複数クラスタに）
+
+**症状**: 同一ニュースが2つ以上のグループに分かれる
+
+**確認方法**:
+`/inspect` でグループを展開 → recompute → `alternativeClusters` で他グループへの類似度が 0.90+ なら過分離の疑い
+
+**対策（優先順）**:
+1. Greedy: `GROUP_CLUSTER_THRESHOLD` を下げる
+2. BERTopic: `BERTOPIC_MIN_CLUSTER_SIZE` を下げる（4 → 3 or 2）
+3. Refine: `REFINE_INTER_THRESHOLD` を下げてmerge判定を積極化
+
+### パターンC: ノイズ過多（単独クラスタが多すぎる）
+
+**症状**: 本来グループ化されるべき記事が単独に
+
+**確認方法**: noise rate が 25% を大きく超える
+
+**対策**:
+1. BERTopic: `BERTOPIC_MIN_CLUSTER_SIZE` を下げる（**最も効果大**）
+2. Greedy: `GROUP_CLUSTER_THRESHOLD` を下げる
+3. BERTopic: `UMAP n_neighbors` をコード内で調整（現在15固定）
+
+### パターンD: Embeddingレベルの問題
+
+**症状**: 類似度の数値は妥当なのに、人間の判断と乖離
+
+**確認方法**: `/inspect` の recompute で `nearestNeighbors` を見て、意味的に近い記事が上位に来ているか確認
+
+**対策**: Embeddingモデルの変更が必要。クラスタリングパラメータでは対処不可。
+
+---
+
+## 4. パラメータ一覧と調整ガイド
+
+### Greedy Cosine（`USE_BERTOPIC=false`）
+
+| 環境変数 | デフォルト | 効果 |
+|:--|:--|:--|
+| `GROUP_CLUSTER_THRESHOLD` | 0.91 | 上げる→クラスタ分裂しやすい、下げる→合流しやすい |
+
+### BERTopic（`USE_BERTOPIC=true`）
+
+| 環境変数 | デフォルト | 効果 |
+|:--|:--|:--|
+| `BERTOPIC_MIN_CLUSTER_SIZE` | 4 | **最重要**。下げる→小クラスタ許容でノイズ減、上げる→大クラスタのみ |
+| `BERTOPIC_UMAP_COMPONENTS` | 15 | 次元数。下げる→構造圧縮強、上げる→詳細保持 |
+
+UMAP の `n_neighbors`（現在15固定）と `min_dist`（現在0.0固定）はコード変更が必要:
+- `n_neighbors`: 上げる→大域構造重視、下げる→局所構造重視
+- `min_dist`: 0.0が密クラスタ向き。上げると散らばる
+
+### Refine（LLM精査）
+
+| 環境変数 | デフォルト | 効果 |
+|:--|:--|:--|
+| `REFINE_INTRA_THRESHOLD` | 0.93 | クラスタ内min類似度がこれ未満→split候補としてLLMに送る |
+| `REFINE_INTER_THRESHOLD` | 0.92 | クラスタ間centroid類似度がこれ以上→merge候補としてLLMに送る |
+| `SKIP_REFINE` | false | trueでrefineステップ全体をスキップ |
+
+---
+
+## 5. 比較評価の手順
+
+### 5.1 A/B比較スクリプト
+
+2つのログファイルを比較する:
+
+```bash
+# 使い方: python3 scripts/compare_clusters.py batch/logs/before.json batch/logs/after.json
+# （存在しない場合は以下のワンライナーで代用）
+
+diff <(
+  cat batch/logs/BEFORE.json | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for e in sorted(d, key=lambda x: -x['size']):
+    if e['size']>=2:
+        titles=', '.join(a['title'][:30] for a in e['articles'][:5])
+        print(f'[{e[\"size\"]}] {titles}')
+"
+) <(
+  cat batch/logs/AFTER.json | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for e in sorted(d, key=lambda x: -x['size']):
+    if e['size']>=2:
+        titles=', '.join(a['title'][:30] for a in e['articles'][:5])
+        print(f'[{e[\"size\"]}] {titles}')
+"
+)
+```
+
+### 5.2 評価観点チェックリスト
+
+変更前後で以下を比較:
+
+- [ ] noise rate は下がったか（過分離改善）
+- [ ] 最大クラスタサイズは妥当か（過合流していないか）
+- [ ] size 2-3 のクラスタが生成されているか
+- [ ] 明らかな誤合流が新たに発生していないか（大クラスタを目視）
+- [ ] avg_similarity の分布が悪化していないか
+
+---
+
+## 6. 段階的な改善ロードマップ
+
+### Phase 1: 現行パラメータの最適化（コード変更なし）
+
+環境変数の調整のみで改善できる範囲を探る。
+
+1. BERTopic使用時: `BERTOPIC_MIN_CLUSTER_SIZE` を 4 → 2 に下げてノイズ率の変化を見る
+2. Refine閾値の調整: `REFINE_INTER_THRESHOLD` を 0.92 → 0.90 に下げてmerge効果を見る
+3. Greedy使用時: `GROUP_CLUSTER_THRESHOLD` を 0.01 刻みで調整
+
+### Phase 2: UMAP パラメータの環境変数化
+
+`n_neighbors` と `min_dist` を環境変数で外出しし、コード変更なしで調整可能にする。
+
+### Phase 3: 評価の定量化
+
+手動ラベル付きデータセット（正解クラスタ）を作成し、ARI（Adjusted Rand Index）などの指標で自動評価。
+→ `/inspect` で修正したグループをゴールドスタンダードとして保存する仕組み。
+
+---
+
+## 7. 変更記録テンプレート
+
+改善を追跡するため、変更ごとに以下を記録する。
+
+```markdown
+### YYYY-MM-DD: {変更内容}
+
+- **変更**: {パラメータ名} {旧値} → {新値}
+- **ログ**: batch/logs/group_XXXXXXXX_XXXXXX.json
+- **結果**:
+  - noise rate: XX% → XX%
+  - max cluster size: XX → XX
+  - 目視で確認した改善点 / 悪化点:
+- **判定**: 採用 / 不採用 / 要追加検証
+```


### PR DESCRIPTION
## Summary
- `analyze-clusters` スキル追加: グルーピングログの品質評価を自動化
- `docs/guide/` にクラスタリングチューニング playbook を追加
- 直近のコードレビュー記録 `CODE_REVIEW.md` を追加

## Test plan
- [x] `/analyze-clusters` を最新ログに対して実行し、レポートが出力されること
- [x] playbook のパラメータ調整提案が現状の挙動と整合すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)